### PR TITLE
Custom SNMP Scripts

### DIFF
--- a/plugins/snmp/Checks/check-snmp-cisco-fw
+++ b/plugins/snmp/Checks/check-snmp-cisco-fw
@@ -1,0 +1,493 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-cisco-fw - Plugin to check firewall stats of a cisco router.
+
+=head1 SYNOPSIS
+
+    check-snmp-cisco-fw [ OPTIONS ]
+
+    check-snmp-cisco-fw --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.1");
+
+$plugin->example(
+    description => "Monitor the firewall of a Cisco Router:",
+    arguments => [
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    keys => [
+        { key => "GCNumAttempted" },
+        { key => "GCNumSetupsAborted" },
+        { key => "GCNumPolicyDeclined" },
+        { key => "GCNumResDeclined" },
+        { key => "GCNumHalfOpen" },
+        { key => "GCNumActive" },
+        { key => "GCNumExpired" },
+        { key => "GCNumAborted" },
+        { key => "GCNumEmbryonic" },
+        { key => "GCSetupRate1" },
+        { key => "GCSetupRate5" },
+        { key => "GCNumRemoteAccess" },
+        { key => "ICMP_NumAttempted" },
+        { key => "ICMP_NumSetupsAborted" },
+        { key => "ICMP_NumPolicyDeclined" },
+        { key => "ICMP_NumResDeclined" },
+        { key => "ICMP_NumHalfOpen" },
+        { key => "ICMP_NumActive" },
+        { key => "ICMP_NumAborted" },
+        { key => "ICMP_SetupRate1" },
+        { key => "ICMP_SetupRate5" },
+        { key => "TCP_NumAttempted" },
+        { key => "TCP_NumSetupsAborted" },
+        { key => "TCP_NumPolicyDeclined" },
+        { key => "TCP_NumResDeclined" },
+        { key => "TCP_NumHalfOpen" },
+        { key => "TCP_NumActive" },
+        { key => "TCP_NumAborted" },
+        { key => "TCP_SetupRate1" },
+        { key => "TCP_SetupRate5" },
+        { key => "UDP_NumAttempted" },
+        { key => "UDP_NumSetupsAborted" },
+        { key => "UDP_NumPolicyDeclined" },
+        { key => "UDP_NumResDeclined" },
+        { key => "UDP_NumHalfOpen" },
+        { key => "UDP_NumActive" },
+        { key => "UDP_NumAborted" },
+        { key => "UDP_SetupRate1" },
+        { key => "UDP_SetupRate5" },
+        { key => "HTTP_NumAttempted" },
+        { key => "HTTP_NumSetupsAborted" },
+        { key => "HTTP_NumPolicyDeclined" },
+        { key => "HTTP_NumResDeclined" },
+        { key => "HTTP_NumHalfOpen" },
+        { key => "HTTP_NumActive" },
+        { key => "HTTP_NumAborted" },
+        { key => "HTTP_SetupRate1" },
+        { key => "HTTP_SetupRate5" },
+        { key => "HTTPS_NumAttempted" },
+        { key => "HTTPS_NumSetupsAborted" },
+        { key => "HTTPS_NumPolicyDeclined" },
+        { key => "HTTPS_NumResDeclined" },
+        { key => "HTTPS_NumHalfOpen" },
+        { key => "HTTPS_NumActive" },
+        { key => "HTTPS_NumAborted" },
+        { key => "HTTPS_SetupRate1" },
+        { key => "HTTPS_SetupRate5" },
+        { key => "DNS_NumAttempted" },
+        { key => "DNS_NumSetupsAborted" },
+        { key => "DNS_NumPolicyDeclined" },
+        { key => "DNS_NumResDeclined" },
+        { key => "DNS_NumHalfOpen" },
+        { key => "DNS_NumActive" },
+        { key => "DNS_NumAborted" },
+        { key => "DNS_SetupRate1" },
+        { key => "DNS_SetupRate5" }
+    ]
+);
+
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+$plugin->add_option(
+    name => "No cache",
+    option => "no-cache",
+    description => "Do not cache SNMP results for 10 seconds.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $fw_global_counter = "1.3.6.1.4.1.9.9.491.1.1.1";
+my $fw_layer4_counter = "1.3.6.1.4.1.9.9.491.1.1.4.1.1";
+my $fw_layer7_counter = "1.3.6.1.4.1.9.9.491.1.1.4.2.1";
+
+#More fuckin counters lol
+
+my %global_counter = (
+   GCNumAttempted      => "1.3.6.1.4.1.9.9.491.1.1.1.1.0",
+   GCNumSetupsAborted  => "1.3.6.1.4.1.9.9.491.1.1.1.2.0",
+   GCNumPolicyDeclined => "1.3.6.1.4.1.9.9.491.1.1.1.3.0",
+   GCNumResDeclined    => "1.3.6.1.4.1.9.9.491.1.1.1.4.0",
+   GCNumExpired        => "1.3.6.1.4.1.9.9.491.1.1.1.7.0",
+   GCNumAborted        => "1.3.6.1.4.1.9.9.491.1.1.1.8.0"
+);
+
+my %global_gauge = (
+   GCNumHalfOpen     => "1.3.6.1.4.1.9.9.491.1.1.1.5.0", 
+   GCNumActive       => "1.3.6.1.4.1.9.9.491.1.1.1.6.0",   
+   GCNumEmbryonic    => "1.3.6.1.4.1.9.9.491.1.1.1.9.0",
+   GCSetupRate1      => "1.3.6.1.4.1.9.9.491.1.1.1.10.0", 
+   GCSetupRate5      => "1.3.6.1.4.1.9.9.491.1.1.1.11.0", 
+   GCNumRemoteAccess => "1.3.6.1.4.1.9.9.491.1.1.1.12.0"
+);
+
+my %icmp_counter = (
+   ICMP_NumAttempted      => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.2.4",
+   ICMP_NumSetupsAborted  => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.3.4",
+   ICMP_NumPolicyDeclined => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.4.4",
+   ICMP_NumResDeclined    => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.5.4",
+   ICMP_NumAborted        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.8.4"
+
+);
+
+my %icmp_gauge = (
+   ICMP_NumHalfOpen       => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.6.4",
+   ICMP_NumActive         => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.7.4",
+   ICMP_SetupRate1        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.9.4",
+   ICMP_SetupRate5        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.10.4"
+);
+
+my %udp_counter = (
+   UDP_NumAttempted      => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.2.6",
+   UDP_NumSetupsAborted  => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.3.6",
+   UDP_NumPolicyDeclined => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.4.6",
+   UDP_NumResDeclined    => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.5.6",
+   UDP_NumAborted        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.8.6"
+
+);
+
+my %udp_gauge = (
+   UDP_NumHalfOpen       => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.6.6",
+   UDP_NumActive         => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.7.6",
+   UDP_SetupRate1        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.9.6",
+   UDP_SetupRate5        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.10.6"
+);
+
+my %tcp_counter = (
+   TCP_NumAttempted      => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.2.7",
+   TCP_NumSetupsAborted  => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.3.7",
+   TCP_NumPolicyDeclined => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.4.7",
+   TCP_NumResDeclined    => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.5.7",
+   TCP_NumAborted        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.8.7"
+
+);
+
+my %tcp_gauge = (
+   TCP_NumHalfOpen       => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.6.7",
+   TCP_NumActive         => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.7.7",
+   TCP_SetupRate1        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.9.7",
+   TCP_SetupRate5        => "1.3.6.1.4.1.9.9.491.1.1.4.1.1.10.7"
+);
+
+my %http_counter = (
+   HTTP_NumAttempted      => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.2.6",
+   HTTP_NumSetupsAborted  => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.3.6",
+   HTTP_NumPolicyDeclined => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.4.6",
+   HTTP_NumResDeclined    => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.5.6",
+   HTTP_NumAborted        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.8.6"
+
+);
+
+my %http_gauge = (
+   HTTP_NumHalfOpen       => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.6.6",
+   HTTP_NumActive         => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.7.6",
+   HTTP_SetupRate1        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.9.6",
+   HTTP_SetupRate5        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.10.6"
+);
+
+my %https_counter = (
+   HTTPS_NumAttempted      => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.2.10",
+   HTTPS_NumSetupsAborted  => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.3.10",
+   HTTPS_NumPolicyDeclined => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.4.10",
+   HTTPS_NumResDeclined    => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.5.10",
+   HTTPS_NumAborted        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.8.10"
+
+);
+
+my %https_gauge = (
+   HTTPS_NumHalfOpen       => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.6.10",
+   HTTPS_NumActive         => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.7.10",
+   HTTPS_SetupRate1        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.9.10",
+   HTTPS_SetupRate5        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.10.10"
+);
+
+my %dns_counter = (
+   DNS_NumAttempted      => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.2.8",
+   DNS_NumSetupsAborted  => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.3.8",
+   DNS_NumPolicyDeclined => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.4.8",
+   DNS_NumResDeclined    => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.5.8",
+   DNS_NumAborted        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.8.8"
+
+);
+
+my %dns_gauge = (
+   DNS_NumHalfOpen       => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.6.8",
+   DNS_NumActive         => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.7.8",
+   DNS_SetupRate1        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.9.8",
+   DNS_SetupRate5        => "1.3.6.1.4.1.9.9.491.1.1.4.2.1.10.8"
+);
+
+# --------------------------------------------------
+# Get cached or latest SNMP data
+# --------------------------------------------------
+
+my ($fw_global_counter_result, $fw_layer4_counter_result, $fw_layer7_counter_result);
+my ($connection_string, $cache_file, $file_stat, $time, $data);
+
+$connection_string = join("_", "bloonix-check-snmp-fw-cache", $opt->{host}, $opt->{community}, $opt->{port});
+$connection_string =~ s/\W/_/g;
+$cache_file = join("/", $plugin->plugin_libdir, $connection_string);
+$cache_file .= ".json";
+$file_stat = [ stat($cache_file) ];
+
+#system("cat $cache_file");
+sysopen my $fh, $cache_file, O_RDWR | O_CREAT or do {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "unable to open file '$cache_file' - $!"
+    );
+};
+
+flock($fh, LOCK_EX);
+
+if ($file_stat->[7]) {
+    my $rest = $file_stat->[7];
+    my $offset = 0;
+    my $done = 0;
+
+    while ($rest > 0) {
+        my $len = sysread($fh, my $buf, $rest, $offset);
+
+        if (!defined $len) {
+            next if $! =~ /^Interrupted/;
+            $plugin->exit(
+                status => "UNKNOWN",
+                message => "unable to read from file '$cache_file' - $!"
+            );
+        }
+
+        $data .= $buf;
+        $rest -= $len;
+        $offset += $len;
+    }
+}
+
+if (!$opt->{no_cache} && defined $file_stat->[10] && $file_stat->[10] + 10 >= time && $data && $data =~ /^{.+}$/) {
+    $data = JSON->new->decode($data);
+    $fw_global_counter_result = $data->{fw}->{global_counter_result};
+    $fw_layer4_counter_result = $data->{fw}->{layer4_counter_result};
+    $fw_layer7_counter_result = $data->{fw}->{layer7_counter_result};
+    $time = $data->{time};
+} else {
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $fw_global_counter_result = $snmp->get_table($fw_global_counter);
+    $fw_layer4_counter_result = $snmp->get_table($fw_layer4_counter);
+    $fw_layer7_counter_result = $snmp->get_table($fw_layer7_counter);
+    
+    $time = time;
+
+    sysseek $fh, 0, 0;
+
+    $data = JSON->new->encode({
+        time => $time,
+        fw => {
+            global_counter_result => $fw_global_counter_result,
+            layer4_counter_result => $fw_layer4_counter_result,
+            layer7_counter_result => $fw_layer7_counter_result
+        }
+    });
+
+    my $rest = length $data;
+    my $offset = 0;
+
+    while ($rest) {
+        my $written = syswrite $fh, $data, $rest, $offset;
+
+        if (!defined $written) {
+            die "system write error: $!";
+        } elsif ($written) {
+            $rest -= $written;
+            $offset += $written;
+        }
+    }
+
+    truncate $fh, length $data;
+}
+
+close $fh;
+
+if (!defined $fw_global_counter_result && !defined $fw_layer4_counter_result && !defined $fw_layer7_counter_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}\n"
+    );
+}
+
+
+# --------------------------------------------------
+# Fetch the statistics from the snmp result
+# --------------------------------------------------
+
+my $stat = { };
+
+
+# --------------------------------------------------
+# Global stats
+# --------------------------------------------------
+
+
+my ($counter_global, $gauge_global, $result_global); 
+
+   $result_global = $fw_global_counter_result;
+   $counter_global = \%global_counter;
+   $gauge_global = \%global_gauge;
+   
+
+foreach my $key (keys %$counter_global, keys %$gauge_global) {
+    my $oid = $counter_global->{$key} ? $counter_global->{$key} : $gauge_global->{$key};
+    $stat->{$key} = $result_global->{"$oid"} || 0;
+}
+
+
+# --------------------------------------------------
+# Layer 4 stats
+# --------------------------------------------------
+
+
+my ($result_layer4, $counter_icmp, $gauge_icmp, $counter_udp, $gauge_udp, $counter_tcp, $gauge_tcp,); 
+
+
+   $result_layer4 = $fw_layer4_counter_result;
+   
+   $counter_icmp = \%icmp_counter;
+   $gauge_icmp = \%icmp_gauge;
+   
+
+foreach my $key (keys %$counter_icmp, keys %$gauge_icmp) {
+                my $oid = $counter_icmp->{$key} ? $counter_icmp->{$key} : $gauge_icmp->{$key};
+                $stat->{$key} = $result_layer4->{"$oid"} || 0;
+}
+
+   $counter_udp = \%udp_counter;
+   $gauge_udp = \%udp_gauge;
+   
+   
+foreach my $key (keys %$counter_udp, keys %$gauge_udp) {
+                my $oid = $counter_udp->{$key} ? $counter_udp->{$key} : $gauge_udp->{$key};
+                $stat->{$key} = $result_layer4->{"$oid"} || 0;
+}
+
+   $counter_tcp = \%tcp_counter;
+   $gauge_tcp = \%tcp_gauge;
+   
+foreach my $key (keys %$counter_tcp, keys %$gauge_tcp) {
+                my $oid = $counter_tcp->{$key} ? $counter_tcp->{$key} : $gauge_tcp->{$key};
+                $stat->{$key} = $result_layer4->{"$oid"} || 0;
+}
+
+# --------------------------------------------------
+# Layer 7 stats
+# --------------------------------------------------
+
+my ($result_layer7, $counter_http, $gauge_http, $counter_https, $gauge_https, $counter_dns, $gauge_dns,); 
+
+
+   $result_layer7 = $fw_layer7_counter_result;
+   
+   $counter_http = \%http_counter;
+   $gauge_http = \%http_gauge;
+   
+
+foreach my $key (keys %$counter_http, keys %$gauge_http) {
+                my $oid = $counter_http->{$key} ? $counter_http->{$key} : $gauge_http->{$key};
+                $stat->{$key} = $result_layer7->{"$oid"} || 0;
+}
+
+   $counter_https = \%https_counter;
+   $gauge_https = \%https_gauge;
+   
+   
+foreach my $key (keys %$counter_https, keys %$gauge_https) {
+                my $oid = $counter_https->{$key} ? $counter_https->{$key} : $gauge_https->{$key};
+                $stat->{$key} = $result_layer7->{"$oid"} || 0;
+}
+
+   $counter_dns = \%dns_counter;
+   $gauge_dns = \%dns_gauge;
+   
+foreach my $key (keys %$counter_dns, keys %$gauge_dns) {
+                my $oid = $counter_dns->{$key} ? $counter_dns->{$key} : $gauge_dns->{$key};
+                $stat->{$key} = $result_layer7->{"$oid"} || 0;
+}
+
+my %delta_keys = (%global_counter, %icmp_counter, %udp_counter, %tcp_counter, %http_counter, %https_counter, %dns_counter);
+
+foreach my $key (keys %delta_keys) {
+    if (!exists $stat->{$key}) {
+        $stat->{$key} = 0;
+    }
+}
+
+$plugin->delta(time => $time, stat => $stat, keys => [ keys %delta_keys ]);
+
+
+  
+
+# --------------------------------------------------
+# Check thresholds
+# --------------------------------------------------
+
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(GCNumActive GCNumHalfOpen GCSetupRate1)],
+    exit => "yes"
+);

--- a/plugins/snmp/Checks/check-snmp-cisco-ios-system-stats
+++ b/plugins/snmp/Checks/check-snmp-cisco-ios-system-stats
@@ -1,0 +1,184 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-cisco-ios-system-stats - Plugin to check cpu and memory of a Cisco IOS device.
+
+=head1 SYNOPSIS
+
+    check-snmp-cisco-ios-system-stats [ OPTIONS ]
+
+    check-snmp-cisco-ios-system-stats --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.1");
+
+$plugin->example(
+    description => "CPU and memory statistics of a Cisco IOS device:",
+    arguments => [
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    keys => [
+        { key => "CPUTotal5sec",       unit => "percent" },
+        { key => "CPUTotal1min",       unit => "percent" },
+        { key => "CPUTotal5min",       unit => "percent" },
+        { key => "CPUInterrupt",       unit => "percent" },
+        { key => "CPUMemUsed",        unit => "bytes" },
+        { key => "CPUMemFree",        unit => "bytes" },
+        { key => "CPUMemLargestFree", unit => "bytes" },
+        { key => "IOMemUsed",         unit => "bytes" },
+		{ key => "IOMemFree",         unit => "bytes" },
+        { key => "IOMemLargestFree",  unit => "bytes" },
+		{ key => "CPUMemUsedPercent", unit => "percent" },
+		{ key => "CPUMemFreePercent", unit => "percent" },
+		{ key => "IOMemUsedPercent",  unit => "percent" },
+		{ key => "IOMemFreePercent",  unit => "percent" },
+    ]
+);
+
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $cpu_base = "1.3.6.1.4.1.9.9.109.1.1.1.1";
+my $memory_base   = "1.3.6.1.4.1.9.9.48.1";
+
+my %cpu_counter = (
+   CPUTotal5sec => "1.3.6.1.4.1.9.9.109.1.1.1.1.6.1",
+   CPUTotal1min => "1.3.6.1.4.1.9.9.109.1.1.1.1.7.1",
+   CPUTotal5min => "1.3.6.1.4.1.9.9.109.1.1.1.1.8.1",
+   CPUInterrupt => "1.3.6.1.4.1.9.9.109.1.1.1.1.11.1"
+);
+
+my %mem_counter = ( 
+   CPUMemUsed        => "1.3.6.1.4.1.9.9.48.1.1.1.5.1",
+   CPUMemFree        => "1.3.6.1.4.1.9.9.48.1.1.1.6.1",
+   CPUMemLargestFree => "1.3.6.1.4.1.9.9.48.1.1.1.7.1",
+   IOMemUsed         => "1.3.6.1.4.1.9.9.48.1.1.1.5.2",
+   IOMemFree         => "1.3.6.1.4.1.9.9.48.1.1.1.6.2",
+   IOMemLargestFree  => "1.3.6.1.4.1.9.9.48.1.1.1.7.2"
+);
+# --------------------------------------------------
+# Get SNMP data
+# --------------------------------------------------
+
+my ($cpu_result, $mem_result);
+
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $mem_result = $snmp->get_table($memory_base);
+    $cpu_result = $snmp->get_table($cpu_base);
+    
+
+
+if (!defined $cpu_result && !defined $mem_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}\n"
+    );
+}
+
+
+
+# --------------------------------------------------
+# Fetch the statistics from the snmp result
+# --------------------------------------------------
+
+my $stat = { };
+
+foreach my $key (keys %cpu_counter) {
+    my $oid = $cpu_counter{$key};
+    if (!exists $cpu_result->{"$oid"}) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid does not exists"
+        );
+    }
+    $stat->{$key} = sprintf("%.0f", $cpu_result->{"$oid"});
+}
+
+foreach my $key (keys %mem_counter) {
+    my $oid = $mem_counter{$key};
+    if (!exists $mem_result->{"$oid"}) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid does not exists"
+        );
+    }
+    $stat->{$key} = sprintf("%.0f", $mem_result->{"$oid"});
+}
+
+$stat->{"CPUMemTotal"} = sprintf("%.0f", $stat->{"CPUMemUsed"} + $stat->{"CPUMemFree"});
+$stat->{"IOMemTotal"} = sprintf("%.0f", $stat->{"IOMemUsed"} + $stat->{"IOMemFree"});
+
+$stat->{"CPUMemUsedPercent"} = sprintf("%.0f", $stat->{"CPUMemUsed"} * 100 / $stat->{"CPUMemTotal"});
+$stat->{"CPUMemFreePercent"} = sprintf("%.0f", $stat->{"CPUMemFree"} * 100 / $stat->{"CPUMemTotal"});
+
+$stat->{"IOMemUsedPercent"} = sprintf("%.0f", $stat->{"IOMemUsed"} * 100 / $stat->{"IOMemTotal"});
+$stat->{"IOMemFreePercent"} = sprintf("%.0f", $stat->{"IOMemFree"} * 100 / $stat->{"IOMemTotal"});
+
+# --------------------------------------------------
+# Check thresholds
+# --------------------------------------------------
+
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(CPUTotal5sec CPUInterrupt CPUMemUsed IOMemUsed)],
+    exit => "yes"
+);

--- a/plugins/snmp/Checks/check-snmp-cpu-linux
+++ b/plugins/snmp/Checks/check-snmp-cpu-linux
@@ -1,0 +1,261 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-cpu-linux - Plugin to check detailed CPU stats of a Linux by snmp.
+
+=head1 SYNOPSIS
+
+    check-snmp-cpu-linux [ OPTIONS ]
+
+    check-snmp-cpu-linux  --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.3");
+
+$plugin->example(
+    description => "Monitor the CPU (1.3.6.1.4.1.2021.11) of a Linux System:",
+    arguments => [
+        cpucount => 4,
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+$plugin->add_option(
+    name => "CPU Count",
+    option => "cpucount",
+    value => "cpucount",
+    value_type => "string",
+    mandatory => 1,
+    description => join(" ",
+        "This is the total number of cpu core available on the system",
+        "If the system uses hyper threading double the sum of all available cores!"
+    )
+);
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    unit => "percent",
+    keys => [qw(user system total iowait idle irq softirq steal guest other)]
+);
+
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+$plugin->add_option(
+    name => "No cache",
+    option => "no-cache",
+    description => "Do not cache SNMP results for 10 seconds.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $cpu_base      = "1.3.6.1.4.1.2021.11";
+
+#counters
+my %cpu_counters = (
+    user    => "1.3.6.1.4.1.2021.11.50",
+    system  => "1.3.6.1.4.1.2021.11.52",
+    iowait  => "1.3.6.1.4.1.2021.11.54",
+    idle    => "1.3.6.1.4.1.2021.11.53",
+    irq     => "1.3.6.1.4.1.2021.11.56",
+    softirq => "1.3.6.1.4.1.2021.11.61",
+    nice    => "1.3.6.1.4.1.2021.11.51",
+    steal   => "1.3.6.1.4.1.2021.11.64",
+    guest   => "1.3.6.1.4.1.2021.11.65"
+	
+);
+
+# --------------------------------------------------
+# Get cached or latest SNMP data
+# --------------------------------------------------
+
+my ($cpu_result);
+my ($connection_string, $cache_file, $file_stat, $time, $data);
+
+$connection_string = join("_", "bloonix-check-snmp-cpu-linux-cache", $opt->{host}, $opt->{community}, $opt->{port});
+$connection_string =~ s/\W/_/g;
+$cache_file = join("/", $plugin->plugin_libdir, $connection_string);
+$cache_file .= ".json";
+$file_stat = [ stat($cache_file) ];
+
+#system("cat $cache_file");
+sysopen my $fh, $cache_file, O_RDWR | O_CREAT or do {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "unable to open file '$cache_file' - $!"
+    );
+};
+
+flock($fh, LOCK_EX);
+
+if ($file_stat->[7]) {
+    my $rest = $file_stat->[7];
+    my $offset = 0;
+    my $done = 0;
+
+    while ($rest > 0) {
+        my $len = sysread($fh, my $buf, $rest, $offset);
+
+        if (!defined $len) {
+            next if $! =~ /^Interrupted/;
+            $plugin->exit(
+                status => "UNKNOWN",
+                message => "unable to read from file '$cache_file' - $!"
+            );
+        }
+
+        $data .= $buf;
+        $rest -= $len;
+        $offset += $len;
+    }
+}
+
+if (!$opt->{no_cache} && defined $file_stat->[10] && $file_stat->[10] + 10 >= time && $data && $data =~ /^{.+}$/) {
+    $data = JSON->new->decode($data);
+    $cpu_result = $data->{cpu}->{result};
+    $time = $data->{time};
+} else {
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $cpu_result = $snmp->get_table($cpu_base, -maxrepetitions => 22);
+    $time = time;
+
+    sysseek $fh, 0, 0;
+
+    $data = JSON->new->encode({
+        time => $time,
+        cpu => {result => $cpu_result}
+    });
+
+    my $rest = length $data;
+    my $offset = 0;
+
+    while ($rest) {
+        my $written = syswrite $fh, $data, $rest, $offset;
+
+        if (!defined $written) {
+            die "system write error: $!";
+        } elsif ($written) {
+            $rest -= $written;
+            $offset += $written;
+        }
+    }
+
+    truncate $fh, length $data;
+}
+
+close $fh;
+
+if (!defined $cpu_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}\n"
+    );
+}
+
+# --------------------------------------------------
+# Let's have a look how many cpu exists
+# --------------------------------------------------
+
+my $cpu = 0;
+
+
+# --------------------------------------------------
+# Fetch the cpu from the snmp result
+# --------------------------------------------------
+
+my $stat = { };
+
+my ($counters, $result);
+
+    $counters = \%cpu_counters;
+    $result = $cpu_result;
+
+foreach my $key (keys %$counters) {
+    my $oid = $counters->{$key};
+    $stat->{$key} = $result->{"$oid.$cpu"} || 0;
+}
+
+my %delta_keys = (%cpu_counters);
+
+foreach my $key (keys %delta_keys) {
+    if (!exists $stat->{$key}) {
+        $stat->{$key} = 0;
+    } 
+}
+
+$plugin->delta(time => $time, stat => $stat, keys => [ keys %delta_keys ]);
+
+my $key_total = 0;
+
+foreach my $key (keys %$stat) {
+	$stat->{$key} = $stat->{$key} / $opt->{cpucount};
+        $stat->{$key} = sprintf("%.2f", $stat->{$key});
+        $key_total += $stat->{$key};
+}
+
+
+$stat->{total} = sprintf('%.2f', $key_total - $stat->{idle});
+
+if ($key_total < 100) {
+    $stat->{other} = sprintf('%.2f', 100 - $key_total);
+    } else {
+    $stat->{other} = sprintf('%.2f', 0);
+    }
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(total user iowait system)],
+    exit => "yes"
+);

--- a/plugins/snmp/Checks/check-snmp-ios-proc
+++ b/plugins/snmp/Checks/check-snmp-ios-proc
@@ -1,0 +1,328 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-ios-proc - Plugin to check Cisco IOS Process by snmp.
+
+=head1 SYNOPSIS
+
+    check-snmp-ios-proc[ OPTIONS ]
+
+    check-snmp-ios-proc --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.3");
+
+$plugin->example(
+    description => "Monitor the process of a Cisco IOS Device:",
+    arguments => [
+        process => "IP Input",
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+$plugin->add_option(
+    name => "Process Name",
+    option => "process",
+    value => "process",
+    value_type => "string",
+    mandatory => 1,
+    description => join(" ",
+        "This is the process you want to check. The process name should",
+        "be the full name from 1.3.6.1.4.1.9.9.109.1.2.1.1.2"
+    )
+);
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    keys => [
+        { key => "MemAllocated", unit => "bytes" },
+        { key => "MemFreed", unit => "bytes" },
+        { key => "Invoked" },
+        { key => "Runtime" },
+        { key => "Util5Sec", unit => "percent" },
+        { key => "Util1Min", unit => "percent" },
+        { key => "Util5Min", unit => "percent" }
+    ]
+);
+
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+$plugin->add_option(
+    name => "No cache",
+    option => "no-cache",
+    description => "Do not cache SNMP results for 10 seconds.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $proc_name_base = "1.3.6.1.4.1.9.9.109.1.2.1.1.2.1";
+my $proc_base      = "1.3.6.1.4.1.9.9.109.1.2.3";
+
+# Some basics, in/out discards and errros
+my %proc_basics = (
+    Util5Sec => "1.3.6.1.4.1.9.9.109.1.2.3.1.5.1",
+    Util1Min => "1.3.6.1.4.1.9.9.109.1.2.3.1.6.1",
+    Util5Min => "1.3.6.1.4.1.9.9.109.1.2.3.1.7.1",
+    Priority => "1.3.6.1.4.1.9.9.109.1.2.3.1.8.1"
+);
+
+
+# counters
+my %proc_counters = (
+    MemAllocated => "1.3.6.1.4.1.9.9.109.1.2.3.1.1.1",
+    MemFreed     => "1.3.6.1.4.1.9.9.109.1.2.3.1.2.1",
+    Invoked      => "1.3.6.1.4.1.9.9.109.1.2.3.1.3.1",
+    Runtime      => "1.3.6.1.4.1.9.9.109.1.2.3.1.4.1"
+);
+
+# 1.3.6.1.4.1.9.9.109.1.2.3.1.8.1 -> cpmProcExtPriorityRev
+my $proc_priority = {
+    1 => "critical",
+    2 => "high",
+    3 => "normal",
+    4 => "low",
+    5 => "notAssigned"
+};
+
+# --------------------------------------------------
+# Get cached or latest SNMP data
+# --------------------------------------------------
+
+my ($proc_result, $proc_names);
+my ($connection_string, $cache_file, $file_stat, $time, $data);
+
+$connection_string = join("_", "bloonix-check-snmp-ios-proc-cache", $opt->{host}, $opt->{community}, $opt->{port});
+$connection_string =~ s/\W/_/g;
+$cache_file = join("/", $plugin->plugin_libdir, $connection_string);
+$cache_file .= ".json";
+$file_stat = [ stat($cache_file) ];
+
+#system("cat $cache_file");
+sysopen my $fh, $cache_file, O_RDWR | O_CREAT or do {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "unable to open file '$cache_file' - $!"
+    );
+};
+
+flock($fh, LOCK_EX);
+
+if ($file_stat->[7]) {
+    my $rest = $file_stat->[7];
+    my $offset = 0;
+    my $done = 0;
+
+    while ($rest > 0) {
+        my $len = sysread($fh, my $buf, $rest, $offset);
+
+        if (!defined $len) {
+            next if $! =~ /^Interrupted/;
+            $plugin->exit(
+                status => "UNKNOWN",
+                message => "unable to read from file '$cache_file' - $!"
+            );
+        }
+
+        $data .= $buf;
+        $rest -= $len;
+        $offset += $len;
+    }
+}
+
+if (!$opt->{no_cache} && defined $file_stat->[10] && $file_stat->[10] + 10 >= time && $data && $data =~ /^{.+}$/) {
+    $data = JSON->new->decode($data);
+    $proc_names = $data->{proc}->{names};
+    $proc_result = $data->{proc}->{result};
+    $time = $data->{time};
+} else {
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $proc_result = $snmp->get_table($proc_base);
+    $proc_names = $snmp->get_table($proc_name_base);
+    $time = time;
+
+    sysseek $fh, 0, 0;
+
+    $data = JSON->new->encode({
+        time => $time,
+        proc => {
+            names => $proc_names,
+            result => $proc_result,
+        }
+    });
+
+    my $rest = length $data;
+    my $offset = 0;
+
+    while ($rest) {
+        my $written = syswrite $fh, $data, $rest, $offset;
+
+        if (!defined $written) {
+            die "system write error: $!";
+        } elsif ($written) {
+            $rest -= $written;
+            $offset += $written;
+        }
+    }
+
+    truncate $fh, length $data;
+}
+
+close $fh;
+
+if (!defined $proc_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}\n"
+    );
+}
+
+# --------------------------------------------------
+# Let's have a look for the pid of the process
+# --------------------------------------------------
+
+my $pid;
+my $search = $proc_names;
+
+foreach my $oid (keys %$search) {
+    if ($oid =~ /(\d+)\z/) {
+        my $pid_num = $1;
+
+        if ($opt->{debug}) {
+            print STDERR ">> found process $oid -> $search->{$oid}\n";
+        }
+
+        if ($opt->{process} =~ /^\d+\z/) {
+            if ($opt->{process} eq $pid_num) {
+                $pid = $pid_num;
+            }
+        } elsif ($search->{$oid} eq $opt->{process}) {
+            $pid = $pid_num;
+        }
+
+        if (defined $pid) {
+            if ($opt->{debug}) {
+                print STDERR ">> process $pid $search->{$oid} matched\n";
+            }
+            last;
+        }
+    }
+}
+
+if (!$pid) {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "process $opt->{process} does not exists"
+    );
+}
+
+# --------------------------------------------------
+# Fetch the statistics from the snmp result
+# --------------------------------------------------
+
+my $stat = { };
+
+foreach my $key (keys %proc_basics) {
+    my $oid = $proc_basics{$key};
+    if (!exists $proc_result->{"$oid.$pid"}) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid.$pid does not exists"
+        );
+    }
+    $stat->{$key} = $proc_result->{"$oid.$pid"};
+}
+
+my ($counters, $result);
+
+
+    $counters = \%proc_counters;
+    $result = $proc_result;
+
+
+foreach my $key (keys %$counters) {
+    my $oid = $counters->{$key};
+    if (!exists $result->{"$oid.$pid"} && $key !~ /nucast/) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid.$pid does not exists"
+        );
+    }
+    $stat->{$key} = $result->{"$oid.$pid"} || 0;
+}
+
+$stat->{Priority} = $proc_priority->{ $stat->{Priority} };
+#delete $stat->{descr};
+
+my %delta_keys = (%proc_counters);
+
+foreach my $key (keys %delta_keys) {
+    if (!exists $stat->{$key}) {
+        $stat->{$key} = 0;
+    }
+}
+
+$plugin->delta(time => $time, stat => $stat, keys => [ keys %delta_keys ]);
+
+# --------------------------------------------------
+# Check thresholds
+# --------------------------------------------------
+
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(Util1Min Runtime Priority)],
+    exit => "yes"
+);

--- a/plugins/snmp/Checks/check-snmp-nbar
+++ b/plugins/snmp/Checks/check-snmp-nbar
@@ -1,0 +1,377 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-nbar - Plugin to check protocol statistics of an interfaces by snmp.
+
+=head1 SYNOPSIS
+
+    check-snmp-nbar [ OPTIONS ]
+
+    check-snmp-nbar --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.3");
+
+
+$plugin->example(
+    description => "Monitor http protocol stats on the interface 10 (1.3.6.1.2.1.2.2.1.2.10) of a cisco router:",
+    arguments => [
+        interface => 10,
+		protocol => "http",
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+$plugin->add_option(
+    name => "Network interface",
+    option => "interface",
+    value => "interface",
+    value_type => "string",
+    mandatory => 1,
+    description => join(" ",
+        "This is the network interface you want to check. The interface name should",
+        "be the last digit of ifDescr (1.3.6.1.2.1.2.2.1.2.X) or the string that is",
+        "found in ifName (1.3.6.1.2.1.31.1.1.1.1)."
+    )
+);
+
+$plugin->add_option(
+    name => "Protocol Name",
+    option => "protocol",
+    value => "protocol",
+    value_type => "string",
+    mandatory => 1,
+    description => join(" ",
+	    "This is the protocol you want to check. For Example http",
+		"You may also use the protocol id from a snmpwalk on",
+		"1.3.6.1.4.1.9.9.244.1.8.1.1.2"
+    )
+);
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    keys => [
+        { key => "in_proto_octets", unit => "bytes" },
+        { key => "in_proto_pkts", unit => "bytes" },
+        { key => "out_proto_octets", unit => "bytes" },
+        { key => "out_proto_pkts", unit => "bytes" }
+    ]
+);
+
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+$plugin->add_option(
+    name => "No cache",
+    option => "no-cache",
+    description => "Do not cache SNMP results for 10 seconds.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $if_name_base            = "1.3.6.1.2.1.31.1.1.1.1";
+my $protocol_name_base      = "1.3.6.1.4.1.9.9.244.1.8.1.1.2";
+my $protocol_counter_ip     = "1.3.6.1.4.1.9.9.244.1.2.1.1.7";
+my $protocol_counter_op     = "1.3.6.1.4.1.9.9.244.1.2.1.1.8";
+my $protocol_counter_io     = "1.3.6.1.4.1.9.9.244.1.2.1.1.9";
+my $protocol_counter_oo     = "1.3.6.1.4.1.9.9.244.1.2.1.1.10";
+
+my %nb_counter_ip = (in_proto_pkts => "1.3.6.1.4.1.9.9.244.1.2.1.1.7");
+my %nb_counter_op = (out_proto_pkts => "1.3.6.1.4.1.9.9.244.1.2.1.1.8");
+my %nb_counter_io = (in_proto_octets  => "1.3.6.1.4.1.9.9.244.1.2.1.1.9");
+my %nb_counter_oo = (out_proto_octets => "1.3.6.1.4.1.9.9.244.1.2.1.1.10");
+
+# --------------------------------------------------
+# Get cached or latest SNMP data
+# --------------------------------------------------
+
+my ($protocol_result, $protocol_counter_ip_result, $protocol_counter_op_result, $protocol_counter_io_result, $protocol_counter_oo_result, $if_names);
+my ($connection_string, $cache_file, $file_stat, $time, $data);
+
+$connection_string = join("_", "bloonix-check-nbar-cache", $opt->{host}, $opt->{community}, $opt->{port});
+$connection_string =~ s/\W/_/g;
+$cache_file = join("/", $plugin->plugin_libdir, $connection_string);
+$cache_file .= ".json";
+$file_stat = [ stat($cache_file) ];
+
+#system("cat $cache_file");
+sysopen my $fh, $cache_file, O_RDWR | O_CREAT or do {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "unable to open file '$cache_file' - $!"
+    );
+};
+
+flock($fh, LOCK_EX);
+
+if ($file_stat->[7]) {
+    my $rest = $file_stat->[7];
+    my $offset = 0;
+    my $done = 0;
+
+    while ($rest > 0) {
+        my $len = sysread($fh, my $buf, $rest, $offset);
+
+        if (!defined $len) {
+            next if $! =~ /^Interrupted/;
+            $plugin->exit(
+                status => "UNKNOWN",
+                message => "unable to read from file '$cache_file' - $!"
+            );
+        }
+
+        $data .= $buf;
+        $rest -= $len;
+        $offset += $len;
+    }
+}
+
+if (!$opt->{no_cache} && defined $file_stat->[10] && $file_stat->[10] + 10 >= time && $data && $data =~ /^{.+}$/) {
+    $data = JSON->new->decode($data);
+    $if_names = $data->{nbar}->{names};
+    $protocol_result = $data->{nbar}->{result};
+    $protocol_counter_ip_result = $data->{nbar}->{ip_result};
+    $protocol_counter_op_result = $data->{nbar}->{op_result};
+    $protocol_counter_io_result = $data->{nbar}->{io_result};
+    $protocol_counter_oo_result = $data->{nbar}->{oo_result};
+    $time = $data->{time};
+} else {
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $protocol_result = $snmp->get_table($protocol_name_base);
+    $if_names = $snmp->get_table($if_name_base);
+    $protocol_counter_ip_result = $snmp->get_table($protocol_counter_ip);
+    $protocol_counter_op_result = $snmp->get_table($protocol_counter_op);
+    $protocol_counter_io_result = $snmp->get_table($protocol_counter_io);
+    $protocol_counter_oo_result = $snmp->get_table($protocol_counter_oo);
+    
+    $time = time;
+
+    sysseek $fh, 0, 0;
+
+    $data = JSON->new->encode({
+        time => $time,
+        nbar => {
+            names => $if_names,
+            result => $protocol_result,
+            ip_result => $protocol_counter_ip_result,
+            op_result => $protocol_counter_op_result,
+            io_result => $protocol_counter_io_result,
+            oo_result => $protocol_counter_oo_result,
+        }
+    });
+
+    my $rest = length $data;
+    my $offset = 0;
+
+    while ($rest) {
+        my $written = syswrite $fh, $data, $rest, $offset;
+
+        if (!defined $written) {
+            die "system write error: $!";
+        } elsif ($written) {
+            $rest -= $written;
+            $offset += $written;
+        }
+    }
+
+    truncate $fh, length $data;
+}
+
+close $fh;
+
+if (!defined $protocol_counter_ip_result && $protocol_counter_op_result && $protocol_counter_io_result && $protocol_counter_oo_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}"
+    );
+}
+
+# --------------------------------------------------
+# Let's have a look how many interfaces exists
+# --------------------------------------------------
+
+my $if;
+my $protocol;
+
+my $search_if = $if_names;
+my $search_protocol = $protocol_result;
+
+foreach my $oid (keys %$search_if) {
+    if ($oid =~ /(\d+)\z/) {
+        my $if_num = $1;
+
+        if ($opt->{debug}) {
+            print STDERR ">> found interface $oid -> $search_if->{$oid}\n";
+        }
+
+        if ($opt->{interface} =~ /^\d+\z/) {
+            if ($opt->{interface} eq $if_num) {
+                $if = $if_num;
+            }
+        } elsif ($search_if->{$oid} eq $opt->{interface}) {
+            $if = $if_num;
+        }
+
+        if (defined $if) {
+            if ($opt->{debug}) {
+                print STDERR ">> interface $search_if->{$oid} matched\n";
+            }
+            last;
+        }
+    }
+}
+
+if (!$if) {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "interface $opt->{interface} does not exists"
+    );
+}
+
+foreach my $oid (keys %$search_protocol) {
+    if ($oid =~ /(\d+)\z/) {
+        my $protocol_num = $1;
+
+        if ($opt->{debug}) {
+            print STDERR ">> found protocol $oid -> $search_protocol->{$oid}\n";
+        }
+
+        if ($opt->{protocol} =~ /^\d+\z/) {
+            if ($opt->{protocol} eq $protocol_num) {
+                $protocol = $protocol_num;
+            }
+        } elsif ($search_protocol->{$oid} eq $opt->{protocol}) {
+            $protocol = $protocol_num;
+        }
+
+        if (defined $protocol) {
+            if ($opt->{debug}) {
+                print STDERR ">> protocol $search_protocol->{$oid} matched\n";
+            }
+            last;
+        }
+    }
+}
+
+if (!$protocol) {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "protocol $opt->{protocol} does not exists"
+    );
+}
+
+# --------------------------------------------------
+# Fetch the statistics from the snmp result
+# --------------------------------------------------
+
+my $stat = { };
+
+my ($counters_ip, $counters_op, $counters_io, $counters_oo, $result_ip, $result_op, $result_io, $result_oo);
+
+
+    $counters_ip = \%nb_counter_ip;
+    $counters_op = \%nb_counter_op;
+    $counters_io = \%nb_counter_io;
+    $counters_oo = \%nb_counter_oo;
+    
+    $result_ip = $protocol_counter_ip_result;
+    $result_op = $protocol_counter_op_result;
+    $result_io = $protocol_counter_io_result;
+    $result_oo = $protocol_counter_oo_result;
+
+
+foreach my $key (keys %$counters_ip) {
+    my $oid = $counters_ip->{$key};
+    $stat->{$key} = $result_ip->{"$oid.$if.$protocol"} || 0;
+}
+
+foreach my $key (keys %$counters_op) {
+    my $oid = $counters_op->{$key};
+    $stat->{$key} = $result_op->{"$oid.$if.$protocol"} || 0;
+}
+
+foreach my $key (keys %$counters_io) {
+    my $oid = $counters_io->{$key};
+    $stat->{$key} = $result_io->{"$oid.$if.$protocol"} || 0;
+}
+
+foreach my $key (keys %$counters_oo) {
+    my $oid = $counters_oo->{$key};
+    $stat->{$key} = $result_oo->{"$oid.$if.$protocol"} || 0;
+}
+
+my %delta_keys = (%nb_counter_ip, %nb_counter_op, %nb_counter_io, %nb_counter_oo);
+
+foreach my $key (keys %delta_keys) {
+    if (!exists $stat->{$key}) {
+        $stat->{$key} = 0;
+    }
+}
+
+$plugin->delta(time => $time, stat => $stat, keys => [ keys %delta_keys ]);
+
+
+# --------------------------------------------------
+# Check thresholds
+# --------------------------------------------------
+
+
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(in_proto_octets out_proto_octets in_proto_pkts out_proto_pkts)],
+    exit => "yes"
+);
+

--- a/plugins/snmp/Checks/check-snmp-qos-queue
+++ b/plugins/snmp/Checks/check-snmp-qos-queue
@@ -1,0 +1,374 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-qos-queue - Plugin to check network interfaces by snmp.
+
+=head1 SYNOPSIS
+
+    check-snmp-qos-queue [ OPTIONS ]
+
+    check-snmp-qos-queue --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.1");
+
+$plugin->example(
+    description => "Monitor the Egress QoS queue of interface of a Cisco Switch:",
+    arguments => [
+        interface => "Gi1/0/1",
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+$plugin->example(
+    description => "Monitor the QoS queue of interface of a Cisco Switch:",
+    arguments => [
+        interface => 10101,
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+$plugin->add_option(
+    name => "Network interface",
+    option => "interface",
+    value => "interface",
+    value_type => "string",
+    mandatory => 1,
+    description => join(" ",
+        "This is the network interface you want to check. The interface name should",
+        "the string that is found in ifName (1.3.6.1.2.1.31.1.1.1.1)."
+    )
+);
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    keys => [
+        { key => "q1_w1_enqueue", unit => "bytes" },
+        { key => "q1_w2_enqueue", unit => "bytes" },
+        { key => "q1_w3_enqueue", unit => "bytes" },
+        { key => "q2_w1_enqueue", unit => "bytes" },
+        { key => "q2_w2_enqueue", unit => "bytes" },
+        { key => "q2_w3_enqueue", unit => "bytes" },
+        { key => "q3_w1_enqueue", unit => "bytes" },
+        { key => "q3_w2_enqueue", unit => "bytes" },
+        { key => "q3_w3_enqueue", unit => "bytes" },
+        { key => "q4_w1_enqueue", unit => "bytes" },
+        { key => "q4_w2_enqueue", unit => "bytes" },
+        { key => "q4_w3_enqueue", unit => "bytes" },
+        { key => "q1_w1_drop", unit => "bytes" },
+        { key => "q1_w2_drop", unit => "bytes" },
+        { key => "q1_w3_drop", unit => "bytes" },
+        { key => "q2_w1_drop", unit => "bytes" },
+        { key => "q2_w2_drop", unit => "bytes" },
+        { key => "q2_w3_drop", unit => "bytes" },
+        { key => "q3_w1_drop", unit => "bytes" },
+        { key => "q3_w2_drop", unit => "bytes" },
+        { key => "q3_w3_drop", unit => "bytes" },
+        { key => "q4_w1_drop", unit => "bytes" },
+        { key => "q4_w2_drop", unit => "bytes" },
+        { key => "q4_w3_drop", unit => "bytes" },
+        { key => "total_enqueue" },
+        { key => "total_drop" }
+    ]
+);
+
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+$plugin->add_option(
+    name => "No cache",
+    option => "no-cache",
+    description => "Do not cache SNMP results for 10 seconds.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $if_name_base = "1.3.6.1.2.1.31.1.1.1.1";
+my $qos_hc_base   = "1.3.6.1.4.1.9.9.189.1.3.5.1";
+
+# --------------------------------------------------
+# Get cached or latest SNMP data
+# --------------------------------------------------
+
+my ($qos_result, $if_names);
+my ($connection_string, $cache_file, $file_stat, $time, $data);
+
+$connection_string = join("_", "bloonix-check-snmp-qos-cache", $opt->{host}, $opt->{community}, $opt->{port});
+$connection_string =~ s/\W/_/g;
+$cache_file = join("/", $plugin->plugin_libdir, $connection_string);
+$cache_file .= ".json";
+$file_stat = [ stat($cache_file) ];
+
+#system("cat $cache_file");
+sysopen my $fh, $cache_file, O_RDWR | O_CREAT or do {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "unable to open file '$cache_file' - $!"
+    );
+};
+
+flock($fh, LOCK_EX);
+
+if ($file_stat->[7]) {
+    my $rest = $file_stat->[7];
+    my $offset = 0;
+    my $done = 0;
+
+    while ($rest > 0) {
+        my $len = sysread($fh, my $buf, $rest, $offset);
+
+        if (!defined $len) {
+            next if $! =~ /^Interrupted/;
+            $plugin->exit(
+                status => "UNKNOWN",
+                message => "unable to read from file '$cache_file' - $!"
+            );
+        }
+
+        $data .= $buf;
+        $rest -= $len;
+        $offset += $len;
+    }
+}
+
+if (!$opt->{no_cache} && defined $file_stat->[10] && $file_stat->[10] + 10 >= time && $data && $data =~ /^{.+}$/) {
+    $data = JSON->new->decode($data);
+    $if_names = $data->{qos}->{names};
+    $qos_result = $data->{qos}->{result};
+    $time = $data->{time};
+} else {
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $if_names = $snmp->get_table($if_name_base);
+    $qos_result = $snmp->get_table($qos_hc_base);
+    
+    $time = time;
+
+    sysseek $fh, 0, 0;
+
+    $data = JSON->new->encode({
+        time => $time,
+        qos => {
+            names => $if_names,
+            result => $qos_result
+        }
+    });
+
+    my $rest = length $data;
+    my $offset = 0;
+
+    while ($rest) {
+        my $written = syswrite $fh, $data, $rest, $offset;
+
+        if (!defined $written) {
+            die "system write error: $!";
+        } elsif ($written) {
+            $rest -= $written;
+            $offset += $written;
+        }
+    }
+
+    truncate $fh, length $data;
+}
+
+close $fh;
+
+if (!defined $qos_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}\n"
+    );
+}
+
+# --------------------------------------------------
+# Let's have a look how many interfaces exists
+# --------------------------------------------------
+
+my $if;
+my $search = $if_names;
+
+foreach my $oid (keys %$search) {
+    if ($oid =~ /(\d+)\z/) {
+        my $if_num = $1;
+
+        if ($opt->{debug}) {
+            print STDERR ">> found interface $oid -> $search->{$oid}\n";
+        }
+
+        if ($opt->{interface} =~ /^\d+\z/) {
+            if ($opt->{interface} eq $if_num) {
+                $if = $if_num;
+            }
+        } elsif ($search->{$oid} eq $opt->{interface}) {
+            $if = $if_num;
+        }
+
+        if (defined $if) {
+            if ($opt->{debug}) {
+                print STDERR ">> interface $search->{$oid} matched\n";
+            }
+            last;
+        }
+    }
+}
+
+if (!$if) {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "interface $opt->{interface} does not exists"
+    );
+}
+
+
+
+# --------------------------------------------------
+# Fetch the statistics from the snmp result
+# --------------------------------------------------
+
+
+my %qos_counter = (
+   q1_w1_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.1.1",
+   q1_w2_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.1.2",
+   q1_w3_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.1.3",
+   q2_w1_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.2.1",
+   q2_w2_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.2.2",
+   q2_w3_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.2.3",
+   q3_w1_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.3.1",
+   q3_w2_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.3.2",
+   q3_w3_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.3.3",
+   q4_w1_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.3.1",
+   q4_w2_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.3.2",
+   q4_w3_enqueue => "1.3.6.1.4.1.9.9.189.1.3.5.1.3.$if.3.3",
+   q1_w1_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.1.1",
+   q1_w2_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.1.2",
+   q1_w3_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.1.3",
+   q2_w1_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.2.1",
+   q2_w2_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.2.2",
+   q2_w3_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.2.3",
+   q3_w1_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.3.1",
+   q3_w2_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.3.2",
+   q3_w3_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.3.3",
+   q4_w1_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.3.1",
+   q4_w2_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.3.2",
+   q4_w3_drop    => "1.3.6.1.4.1.9.9.189.1.3.5.1.4.$if.3.3"
+);
+
+
+
+my $stat = { };
+
+my ($counters, $result);
+
+
+    $counters = \%qos_counter;
+    $result = $qos_result;
+
+
+foreach my $key (keys %$counters) {
+    my $oid = $counters->{$key};
+    
+
+        if (!exists $result->{"$oid"} && $key !~ /nucast/) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid.$if does not exists"
+            );
+           }
+        $stat->{$key} = $result->{"$oid"} || 0;
+}
+
+
+
+my %delta_keys = (%qos_counter);
+
+foreach my $key (keys %delta_keys) {
+    if (!exists $stat->{$key}) {
+        $stat->{$key} = 0;
+    }
+}
+
+$plugin->delta(time => $time, stat => $stat, keys => [ keys %delta_keys ]);
+
+my $total_enqueue = 0;
+my $total_drop = 0;
+
+foreach my $key (keys %$stat) {
+     my $key_name = $key;
+     my $key_value = $stat->{$key};
+
+     if ($key_name =~ /.*_enqueue/) {
+        $total_enqueue = $total_enqueue + $key_value;
+        } elsif ($key_name =~ /.*_drop/) { 
+        $total_drop = $total_drop + $key_value;
+        }
+}
+
+$stat->{'total_enqueue'} = $total_enqueue;
+$stat->{'total_drop'} = $total_drop;
+
+ 
+
+# --------------------------------------------------
+# Check thresholds
+# --------------------------------------------------
+
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(total_enqueue total_drop)],
+    exit => "yes"
+);

--- a/plugins/snmp/Checks/check-snmp-rmon
+++ b/plugins/snmp/Checks/check-snmp-rmon
@@ -1,0 +1,341 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-rmon - Plugin to check interfaces rmon stats by snmp.
+
+=head1 SYNOPSIS
+
+    check-snmp-rmon [ OPTIONS ]
+
+    check-snmp-rmon --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.1");
+
+$plugin->example(
+    description => "Monitor the rmon stats of a interface on a switch:",
+    arguments => [
+        interface => "Gi1/0/1",
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+$plugin->example(
+    description => "Monitor the rmon stats of a interface on a switch:",
+    arguments => [
+        interface => 10101,
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+$plugin->add_option(
+    name => "Network interface",
+    option => "interface",
+    value => "interface",
+    value_type => "string",
+    mandatory => 1,
+    description => join(" ",
+        "This is the network interface you want to check. The interface name should",
+        "the string that is found in ifName (1.3.6.1.2.1.31.1.1.1.1)."
+    )
+);
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    keys => [
+        { key => "DropEvents" },
+        { key => "Octets", unit => "bytes" },
+        { key => "Pkts" },
+        { key => "BroadcastPkts" },
+        { key => "MulticastPkts" },
+        { key => "CRCAlignErrors" },
+        { key => "UndersizePkts" },
+        { key => "OversizePkts" },
+        { key => "Fragments" },
+        { key => "Jabbers" },
+        { key => "Collisions" },
+        { key => "Pkts64Octets" },
+        { key => "Pkts65to127Octets" },
+        { key => "Pkts128to255Octets" },
+        { key => "Pkts256to511Octets" },
+        { key => "Pkts512to1023Octets" },
+        { key => "Pkts1024to1518Octets" }
+    ]
+);
+
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+$plugin->add_option(
+    name => "No cache",
+    option => "no-cache",
+    description => "Do not cache SNMP results for 10 seconds.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $if_name_base = "1.3.6.1.2.1.31.1.1.1.1";
+my $rmon_base   = "1.3.6.1.2.1.16.1.1.1";
+
+my %rmon_counter = (
+   DropEvents           => "1.3.6.1.2.1.16.1.1.1.3",
+   Octets               => "1.3.6.1.2.1.16.1.1.1.4",
+   Pkts                 => "1.3.6.1.2.1.16.1.1.1.5",
+   BroadcastPkts        => "1.3.6.1.2.1.16.1.1.1.6",
+   MulticastPkts        => "1.3.6.1.2.1.16.1.1.1.7",
+   CRCAlignErrors       => "1.3.6.1.2.1.16.1.1.1.8",
+   UndersizePkts        => "1.3.6.1.2.1.16.1.1.1.9",
+   OversizePkts         => "1.3.6.1.2.1.16.1.1.1.10",
+   Fragments            => "1.3.6.1.2.1.16.1.1.1.11",
+   Jabbers              => "1.3.6.1.2.1.16.1.1.1.12",
+   Collisions           => "1.3.6.1.2.1.16.1.1.1.13",
+   Pkts64Octets         => "1.3.6.1.2.1.16.1.1.1.14",
+   Pkts65to127Octets    => "1.3.6.1.2.1.16.1.1.1.15",
+   Pkts128to255Octets   => "1.3.6.1.2.1.16.1.1.1.16",
+   Pkts256to511Octets   => "1.3.6.1.2.1.16.1.1.1.17",
+   Pkts512to1023Octets  => "1.3.6.1.2.1.16.1.1.1.18",
+   Pkts1024to1518Octets => "1.3.6.1.2.1.16.1.1.1.19"
+);
+
+
+# --------------------------------------------------
+# Get cached or latest SNMP data
+# --------------------------------------------------
+
+my ($rmon_result, $if_names);
+my ($connection_string, $cache_file, $file_stat, $time, $data);
+
+$connection_string = join("_", "bloonix-check-snmp-rmon-cache", $opt->{host}, $opt->{community}, $opt->{port});
+$connection_string =~ s/\W/_/g;
+$cache_file = join("/", $plugin->plugin_libdir, $connection_string);
+$cache_file .= ".json";
+$file_stat = [ stat($cache_file) ];
+
+#system("cat $cache_file");
+sysopen my $fh, $cache_file, O_RDWR | O_CREAT or do {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "unable to open file '$cache_file' - $!"
+    );
+};
+
+flock($fh, LOCK_EX);
+
+if ($file_stat->[7]) {
+    my $rest = $file_stat->[7];
+    my $offset = 0;
+    my $done = 0;
+
+    while ($rest > 0) {
+        my $len = sysread($fh, my $buf, $rest, $offset);
+
+        if (!defined $len) {
+            next if $! =~ /^Interrupted/;
+            $plugin->exit(
+                status => "UNKNOWN",
+                message => "unable to read from file '$cache_file' - $!"
+            );
+        }
+
+        $data .= $buf;
+        $rest -= $len;
+        $offset += $len;
+    }
+}
+
+if (!$opt->{no_cache} && defined $file_stat->[10] && $file_stat->[10] + 10 >= time && $data && $data =~ /^{.+}$/) {
+    $data = JSON->new->decode($data);
+    $if_names = $data->{qos}->{names};
+    $rmon_result = $data->{qos}->{result};
+    $time = $data->{time};
+} else {
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $if_names = $snmp->get_table($if_name_base);
+    $rmon_result = $snmp->get_table($rmon_base);
+    
+    $time = time;
+
+    sysseek $fh, 0, 0;
+
+    $data = JSON->new->encode({
+        time => $time,
+        qos => {
+            names => $if_names,
+            result => $rmon_result
+        }
+    });
+
+    my $rest = length $data;
+    my $offset = 0;
+
+    while ($rest) {
+        my $written = syswrite $fh, $data, $rest, $offset;
+
+        if (!defined $written) {
+            die "system write error: $!";
+        } elsif ($written) {
+            $rest -= $written;
+            $offset += $written;
+        }
+    }
+
+    truncate $fh, length $data;
+}
+
+close $fh;
+
+if (!defined $rmon_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}\n"
+    );
+}
+
+# --------------------------------------------------
+# Let's have a look how many interfaces exists
+# --------------------------------------------------
+
+my $if;
+my $search = $if_names;
+
+foreach my $oid (keys %$search) {
+    if ($oid =~ /(\d+)\z/) {
+        my $if_num = $1;
+
+        if ($opt->{debug}) {
+            print STDERR ">> found interface $oid -> $search->{$oid}\n";
+        }
+
+        if ($opt->{interface} =~ /^\d+\z/) {
+            if ($opt->{interface} eq $if_num) {
+                $if = $if_num;
+            }
+        } elsif ($search->{$oid} eq $opt->{interface}) {
+            $if = $if_num;
+        }
+
+        if (defined $if) {
+            if ($opt->{debug}) {
+                print STDERR ">> interface $search->{$oid} matched\n";
+            }
+            last;
+        }
+    }
+}
+
+if (!$if) {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "interface $opt->{interface} does not exists"
+    );
+}
+
+
+
+# --------------------------------------------------
+# Fetch the statistics from the snmp result
+# --------------------------------------------------
+
+
+
+my $stat = { };
+
+my ($counters, $result);
+
+
+    $counters = \%rmon_counter;
+    $result = $rmon_result;
+
+
+foreach my $key (keys %$counters) {
+    my $oid = $counters->{$key};
+    
+
+        if (!exists $result->{"$oid.$if"} && $key !~ /nucast/) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid.$if does not exists"
+            );
+           }
+        $stat->{$key} = $result->{"$oid.$if"} || 0;
+}
+
+
+
+my %delta_keys = (%rmon_counter);
+
+foreach my $key (keys %delta_keys) {
+    if (!exists $stat->{$key}) {
+        $stat->{$key} = 0;
+    }
+}
+
+$plugin->delta(time => $time, stat => $stat, keys => [ keys %delta_keys ]);
+
+  
+
+# --------------------------------------------------
+# Check thresholds
+# --------------------------------------------------
+
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(Octets Pkts)],
+    exit => "yes"
+);

--- a/plugins/snmp/Checks/check-snmp-syno-disk
+++ b/plugins/snmp/Checks/check-snmp-syno-disk
@@ -1,0 +1,334 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-syno-disk - Plugin to check network interfaces by snmp.
+
+=head1 SYNOPSIS
+
+    check-snmp-syno-disk [ OPTIONS ]
+
+    check-snmp-syno-disk  --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.3");
+
+$plugin->example(
+    description => "Monitor the disk (1.3.6.1.4.1.6574.101) of a Synology NAS:",
+    arguments => [
+        disk => "sda",
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+
+$plugin->add_option(
+    name => "Disk",
+    option => "disk",
+    value => "disk",
+    value_type => "string",
+    mandatory => 1,
+    description => join(" ",
+        "This is the disk you want to check. The disk name should",
+        "be the last digit of diskIOIndex(1.3.6.1.4.1.6574.101.1.1.X) or the string that is",
+        "found in diskIODevice (1.3.6.1.4.1.6574.101.1.1.2)."
+    )
+);
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    keys => [
+        { key => "bytes_read", unit => "bytes" },
+        { key => "bytes_write", unit => "bytes" },
+        { key => "iops_read", unit => "bytes" },
+        { key => "iops_write", unit => "bytes" },
+        { key => "avg_load", unit => "percent" },
+        { key => "avg_write_io_size", unit => "bytes" },
+        { key => "avg_read_io_size", unit => "bytes" }
+
+    ]
+);
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+$plugin->add_option(
+    name => "No cache",
+    option => "no-cache",
+    description => "Do not cache SNMP results for 10 seconds.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $disk_name_base = "1.3.6.1.4.1.6574.101.1.1.2";
+my $disk_base      = "1.3.6.1.4.1.6574.101.1.1";
+
+# Average Disk Load
+my %disk_basics = (
+    avg_load  => "1.3.6.1.4.1.6574.101.1.1.9"
+);
+
+#counters
+my %disk_counters = (
+    bytes_read      => "1.3.6.1.4.1.6574.101.1.1.12",
+    bytes_write     => "1.3.6.1.4.1.6574.101.1.1.13",
+    iops_read       => "1.3.6.1.4.1.6574.101.1.1.5",
+    iops_write      => "1.3.6.1.4.1.6574.101.1.1.6"
+);
+
+# --------------------------------------------------
+# Get cached or latest SNMP data
+# --------------------------------------------------
+
+my ($disk_result, $disk_names);
+my ($connection_string, $cache_file, $file_stat, $time, $data);
+
+$connection_string = join("_", "bloonix-check-snmp-syno-disk-cache", $opt->{host}, $opt->{community}, $opt->{port});
+$connection_string =~ s/\W/_/g;
+$cache_file = join("/", $plugin->plugin_libdir, $connection_string);
+$cache_file .= ".json";
+$file_stat = [ stat($cache_file) ];
+
+#system("cat $cache_file");
+sysopen my $fh, $cache_file, O_RDWR | O_CREAT or do {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "unable to open file '$cache_file' - $!"
+    );
+};
+
+flock($fh, LOCK_EX);
+
+if ($file_stat->[7]) {
+    my $rest = $file_stat->[7];
+    my $offset = 0;
+    my $done = 0;
+
+    while ($rest > 0) {
+        my $len = sysread($fh, my $buf, $rest, $offset);
+
+        if (!defined $len) {
+            next if $! =~ /^Interrupted/;
+            $plugin->exit(
+                status => "UNKNOWN",
+                message => "unable to read from file '$cache_file' - $!"
+            );
+        }
+
+        $data .= $buf;
+        $rest -= $len;
+        $offset += $len;
+    }
+}
+
+if (!$opt->{no_cache} && defined $file_stat->[10] && $file_stat->[10] + 10 >= time && $data && $data =~ /^{.+}$/) {
+    $data = JSON->new->decode($data);
+    $disk_names = $data->{disk}->{names};
+    $disk_result = $data->{disk}->{result};
+    $time = $data->{time};
+} else {
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $disk_result = $snmp->get_table($disk_base, -maxrepetitions  => 54);
+    $disk_names = $snmp->get_table($disk_name_base, -maxrepetitions  => 54);
+    $time = time;
+
+    sysseek $fh, 0, 0;
+
+    $data = JSON->new->encode({
+        time => $time,
+        disk => {
+            names => $disk_names,
+            result => $disk_result
+        }
+    });
+
+    my $rest = length $data;
+    my $offset = 0;
+
+    while ($rest) {
+        my $written = syswrite $fh, $data, $rest, $offset;
+
+        if (!defined $written) {
+            die "system write error: $!";
+        } elsif ($written) {
+            $rest -= $written;
+            $offset += $written;
+        }
+    }
+
+    truncate $fh, length $data;
+}
+
+close $fh;
+
+if (!defined $disk_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}\n"
+    );
+}
+
+# --------------------------------------------------
+# Let's have a look how many disks exists
+# --------------------------------------------------
+
+my $disk;
+my $search = $disk_names // $disk_result;
+
+foreach my $oid (keys %$search) {
+    if ($oid =~ /(\d+)\z/) {
+        my $disk_num = $1;
+
+        if ($opt->{debug}) {
+            print STDERR ">> found disk $oid -> $search->{$oid}\n";
+        }
+
+        if ($opt->{disk} =~ /^\d+\z/) {
+            if ($opt->{disk} eq $disk_num) {
+                $disk = $disk_num;
+            }
+        } elsif ($search->{$oid} eq $opt->{disk}) {
+            $disk = $disk_num;
+        }
+
+        if (defined $disk) {
+            if ($opt->{debug}) {
+                print STDERR ">> disk $search->{$oid} matched\n";
+            }
+            last;
+        }
+    }
+}
+
+if (!$disk) {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "disk $opt->{disk} does not exists"
+    );
+}
+
+# --------------------------------------------------
+# Fetch the disk from the snmp result
+# --------------------------------------------------
+
+my $stat = { };
+
+foreach my $key (keys %disk_basics) {
+    my $oid = $disk_basics{$key};
+    if (!exists $disk_result->{"$oid.$disk"}) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid.$disk does not exists"
+        );
+    }
+    $stat->{$key} = $disk_result->{"$oid.$disk"};
+}
+
+my ($counters, $result);
+
+    $counters = \%disk_counters;
+    $result = $disk_result;
+
+foreach my $key (keys %$counters) {
+    my $oid = $counters->{$key};
+    if (!exists $result->{"$oid.$disk"} && $key !~ /nucast/) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid.$disk does not exists"
+        );
+    }
+    $stat->{$key} = $result->{"$oid.$disk"} || 0;
+}
+
+my %delta_keys = (%disk_counters);
+
+foreach my $key (keys %delta_keys) {
+    if (!exists $stat->{$key}) {
+        $stat->{$key} = 0;
+    }
+}
+
+$plugin->delta(time => $time, stat => $stat, keys => [ keys %delta_keys ]);
+
+my ($avg_read_io_size, $avg_write_io_size);
+
+if ($stat->{iops_read} == 0)
+   {
+   $avg_read_io_size = '0.00';
+   $stat->{'avg_read_io_size'} = "$avg_read_io_size";
+   }
+else
+   {
+   $avg_read_io_size = ($stat->{bytes_read} / $stat->{iops_read});
+   $avg_read_io_size = sprintf("%.2f", $avg_read_io_size);
+   $stat->{'avg_read_io_size'} = $avg_read_io_size;
+   }
+
+if ($stat->{iops_write} == 0)
+   {
+   $avg_write_io_size = '0.00';
+   $stat->{'avg_write_io_size'} = "$avg_write_io_size";
+   }
+else
+   {
+   $avg_write_io_size = ($stat->{bytes_write} / $stat->{iops_write});
+   $avg_write_io_size = sprintf("%.2f", $avg_write_io_size);
+   $stat->{'avg_write_io_size'} = $avg_write_io_size;
+   }
+
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(avg_load bytes_read bytes_write)],
+    exit => "yes"
+);

--- a/plugins/snmp/Checks/check-snmp-syno-lv
+++ b/plugins/snmp/Checks/check-snmp-syno-lv
@@ -1,0 +1,333 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp-syno-lv - Plugin to check logical volume of Synology NAS by snmp.
+
+=head1 SYNOPSIS
+
+    check-snmp-syno-lv [ OPTIONS ]
+
+    check-snmp-syno-lv  --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+use Fcntl qw(:flock :DEFAULT);
+use Net::SNMP;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.3");
+
+$plugin->example(
+    description => "Monitor the volume (1.3.6.1.4.1.6574.102) of a Synology NAS:",
+    arguments => [
+        lv => "dm-1",
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        "snmp-version" => 1
+    ]
+);
+
+
+$plugin->add_option(
+    name => "Logical Volume",
+    option => "lv",
+    value => "lv",
+    value_type => "string",
+    mandatory => 1,
+    description => join(" ",
+        "This is the logical volume you want to check. The lv name should",
+        "be the last digit of lvIOIndex(1.3.6.1.4.1.6574.102.1.1.X) or the string that is",
+        "found in lvIODevice (1.3.6.1.4.1.6574.102.1.1.2)."
+    )
+);
+
+$plugin->has_snmp;
+$plugin->has_debug;
+
+$plugin->has_threshold(
+    keys => [
+        { key => "bytes_read", unit => "bytes" },
+        { key => "bytes_write", unit => "bytes" },
+        { key => "iops_read", unit => "bytes" },
+        { key => "iops_write", unit => "bytes" },
+        { key => "avg_load", unit => "percent" },
+        { key => "avg_write_io_size", unit => "bytes" },
+        { key => "avg_read_io_size", unit => "bytes" }
+
+    ]
+);
+
+$plugin->add_option(
+    name => "Debug",
+    option => "debug",
+    description => "Turn on debugging. Just useful if you want to test something.",
+    command_line_only => 1
+);
+
+$plugin->add_option(
+    name => "No cache",
+    option => "no-cache",
+    description => "Do not cache SNMP results for 10 seconds.",
+    command_line_only => 1
+);
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# Some OIDs
+# --------------------------------------------------
+
+# Base table oids
+my $lv_name_base = "1.3.6.1.4.1.6574.102.1.1.2";
+my $lv_base      = "1.3.6.1.4.1.6574.102.1.1";
+
+# Average lv Load
+my %lv_basics = (
+    avg_load  => "1.3.6.1.4.1.6574.102.1.1.9"
+);
+
+#counters
+my %lv_counters = (
+    bytes_read      => "1.3.6.1.4.1.6574.102.1.1.12",
+    bytes_write     => "1.3.6.1.4.1.6574.102.1.1.13",
+    iops_read       => "1.3.6.1.4.1.6574.102.1.1.5",
+    iops_write      => "1.3.6.1.4.1.6574.102.1.1.6"
+);
+
+# --------------------------------------------------
+# Get cached or latest SNMP data
+# --------------------------------------------------
+
+my ($lv_result, $lv_names);
+my ($connection_string, $cache_file, $file_stat, $time, $data);
+
+$connection_string = join("_", "bloonix-check-snmp-syno-lv-cache", $opt->{host}, $opt->{community}, $opt->{port});
+$connection_string =~ s/\W/_/g;
+$cache_file = join("/", $plugin->plugin_libdir, $connection_string);
+$cache_file .= ".json";
+$file_stat = [ stat($cache_file) ];
+
+#system("cat $cache_file");
+sysopen my $fh, $cache_file, O_RDWR | O_CREAT or do {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "unable to open file '$cache_file' - $!"
+    );
+};
+
+flock($fh, LOCK_EX);
+
+if ($file_stat->[7]) {
+    my $rest = $file_stat->[7];
+    my $offset = 0;
+    my $done = 0;
+
+    while ($rest > 0) {
+        my $len = sysread($fh, my $buf, $rest, $offset);
+
+        if (!defined $len) {
+            next if $! =~ /^Interrupted/;
+            $plugin->exit(
+                status => "UNKNOWN",
+                message => "unable to read from file '$cache_file' - $!"
+            );
+        }
+
+        $data .= $buf;
+        $rest -= $len;
+        $offset += $len;
+    }
+}
+
+if (!$opt->{no_cache} && defined $file_stat->[10] && $file_stat->[10] + 10 >= time && $data && $data =~ /^{.+}$/) {
+    $data = JSON->new->decode($data);
+    $lv_names = $data->{lv}->{names};
+    $lv_result = $data->{lv}->{result};
+    $time = $data->{time};
+} else {
+    my $snmp = $plugin->start_snmp_session;
+    $snmp->max_msg_size(65535);
+    $lv_result = $snmp->get_table($lv_base, -maxrepetitions  => 40);
+    $lv_names = $snmp->get_table($lv_name_base, -maxrepetitions  => 40);
+    $time = time;
+
+    sysseek $fh, 0, 0;
+
+    $data = JSON->new->encode({
+        time => $time,
+        lv => {
+            names => $lv_names,
+            result => $lv_result
+        }
+    });
+
+    my $rest = length $data;
+    my $offset = 0;
+
+    while ($rest) {
+        my $written = syswrite $fh, $data, $rest, $offset;
+
+        if (!defined $written) {
+            die "system write error: $!";
+        } elsif ($written) {
+            $rest -= $written;
+            $offset += $written;
+        }
+    }
+
+    truncate $fh, length $data;
+}
+
+close $fh;
+
+if (!defined $lv_result) {
+    $plugin->exit(
+        status => "CRITICAL",
+        message => "unable to get oid table from host $opt->{host}\n"
+    );
+}
+
+# --------------------------------------------------
+# Let's have a look how many lvs exists
+# --------------------------------------------------
+
+my $lv;
+my $search = $lv_names // $lv_result;
+
+foreach my $oid (keys %$search) {
+    if ($oid =~ /(\d+)\z/) {
+        my $lv_num = $1;
+
+        if ($opt->{debug}) {
+            print STDERR ">> found lv $oid -> $search->{$oid}\n";
+        }
+
+        if ($opt->{lv} =~ /^\d+\z/) {
+            if ($opt->{lv} eq $lv_num) {
+                $lv = $lv_num;
+            }
+        } elsif ($search->{$oid} eq $opt->{lv}) {
+            $lv = $lv_num;
+        }
+
+        if (defined $lv) {
+            if ($opt->{debug}) {
+                print STDERR ">> lv $search->{$oid} matched\n";
+            }
+            last;
+        }
+    }
+}
+
+if (!$lv) {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "lv $opt->{lv} does not exists"
+    );
+}
+
+# --------------------------------------------------
+# Fetch the lv from the snmp result
+# --------------------------------------------------
+
+my $stat = { };
+
+foreach my $key (keys %lv_basics) {
+    my $oid = $lv_basics{$key};
+    if (!exists $lv_result->{"$oid.$lv"}) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid.$lv does not exists"
+        );
+    }
+    $stat->{$key} = $lv_result->{"$oid.$lv"};
+}
+
+my ($counters, $result);
+
+    $counters = \%lv_counters;
+    $result = $lv_result;
+
+foreach my $key (keys %$counters) {
+    my $oid = $counters->{$key};
+    if (!exists $result->{"$oid.$lv"} && $key !~ /nucast/) {
+        $plugin->exit(
+            status => "UNKOWN",
+            message => "oid $oid.$lv does not exists"
+        );
+    }
+    $stat->{$key} = $result->{"$oid.$lv"} || 0;
+}
+
+my %delta_keys = (%lv_counters);
+
+foreach my $key (keys %delta_keys) {
+    if (!exists $stat->{$key}) {
+        $stat->{$key} = 0;
+    }
+}
+
+$plugin->delta(time => $time, stat => $stat, keys => [ keys %delta_keys ]);
+
+my ($avg_read_io_size, $avg_write_io_size);
+
+if ($stat->{iops_read} == 0)
+   {
+   $avg_read_io_size = '0.00';
+   $stat->{'avg_read_io_size'} = "$avg_read_io_size";
+   }
+else
+   {
+   $avg_read_io_size = ($stat->{bytes_read} / $stat->{iops_read});
+   $avg_read_io_size = sprintf("%.2f", $avg_read_io_size);
+   $stat->{'avg_read_io_size'} = $avg_read_io_size;
+   }
+
+if ($stat->{iops_write} == 0)
+   {
+   $avg_write_io_size = '0.00';
+   $stat->{'avg_write_io_size'} = "$avg_write_io_size";
+   }
+else
+   {
+   $avg_write_io_size = ($stat->{bytes_write} / $stat->{iops_write});
+   $avg_write_io_size = sprintf("%.2f", $avg_write_io_size);
+   $stat->{'avg_write_io_size'} = $avg_write_io_size;
+   }
+
+$plugin->check_thresholds(
+    stats => $stat,
+    upshot_keys => [qw(avg_load bytes_read bytes_write)],
+    exit => "yes"
+);

--- a/plugins/snmp/Checks/check-snmp-temperature
+++ b/plugins/snmp/Checks/check-snmp-temperature
@@ -1,0 +1,132 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+check-snmp - Plugin to check a system simple over snmp.
+
+=head1 SYNOPSIS
+
+    check-snmp-temperature [ OPTIONS ]
+
+    check-snmp-temperature --help
+
+=head1 REPORTING BUGS
+
+Please report all bugs to <support(at)bloonix.de>.
+
+=head1 AUTHOR
+
+Jonny Schulz <support(at)bloonix.de>.
+
+=head1 POWERED BY
+
+     _    __ _____ _____ __  __ __ __   __
+    | |__|  |     |     |  \|  |__|\  \/  /
+    |  . |  |  |  |  |  |      |  | >    <
+    |____|__|_____|_____|__|\__|__|/__/\__\
+
+=head1 COPYRIGHT
+
+Copyright (C) 2014 by Jonny Schulz. All rights reserved.
+
+=cut
+
+use strict;
+use warnings;
+use Bloonix::Plugin;
+
+# --------------------------------------------------
+# Plugin options
+# --------------------------------------------------
+
+my $plugin = Bloonix::Plugin->new(version => "0.1");
+
+$plugin->example(
+    description => "Example to check if a system is alive:",
+    arguments => [
+        host => "127.0.0.1",
+        port => 161,
+        community => "public",
+        oid => "1.3.6.1.2.1.1.5.0"
+    ]
+);
+
+$plugin->has_snmp;
+
+$plugin->add_option(
+    name => "The OID to check",
+    option => "oid",
+    value => "string",
+    value_type => "string",
+    regex => qr/^[^\s]+\z/,
+    default => "1.3.6.1.2.1.1.5.0",
+    mandatory => 1,
+    description => "The OID to check."
+);
+
+$plugin->has_threshold(keys => [ { key => "temperature" } ]);
+
+
+# --------------------------------------------------
+# Parse options
+# --------------------------------------------------
+
+my $opt = $plugin->parse_options;
+
+# --------------------------------------------------
+# SNMP connection
+# --------------------------------------------------
+
+my $snmp = $plugin->start_snmp_session;
+
+# --------------------------------------------------
+# Load statistics
+# --------------------------------------------------
+
+my $response = $snmp->get_request($opt->{oid});
+
+if (!defined $response) {
+    my $message = "ERROR: ". $snmp->error;
+    $snmp->close;
+    $plugin->exit(
+        status => "CRITICAL",
+        message => $message
+    );
+}
+
+$snmp->close;
+
+# --------------------------------------------------
+# Check warning and critical
+# --------------------------------------------------
+
+my $value = $response->{$opt->{oid}};
+#my temperature = $response->{$opt->{oid}};
+
+if (!defined $value) {
+    $plugin->exit(
+        status => "UNKNOWN",
+        message => "oid $opt->{oid} does not exist"
+    );
+}
+
+
+if ($opt->{warning} || $opt->{critical}) {
+    my $result = $plugin->check_thresholds(
+        stats => { "temperature" => $value },
+        upshot_keys => [ "temperature" ]
+    );
+
+    $plugin->exit(
+        status => $result->{status},
+        message => $result->{upshot},
+	stats => { "temperature" => "$value" }
+    );
+}
+
+$plugin->exit(
+    status => "OK",
+    message => "Temperature OK: $value",
+    stats => { "temperature" => "$value" }
+);
+

--- a/plugins/snmp/Configs/Import/plugin-snmp-cisco-fw
+++ b/plugins/snmp/Configs/Import/plugin-snmp-cisco-fw
@@ -1,0 +1,1431 @@
+{
+   "statistic" : [
+      {
+         "description" : "Number of connections which are attempted to be set up.",
+         "units" : "default",
+         "alias" : "GCNumAttempted",
+         "statkey" : "GCNumAttempted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were aborted.",
+         "units" : "default",
+         "alias" : "GCNumSetupsAborted",
+         "statkey" : "GCNumSetupsAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined due to security reasons.",
+         "units" : "default",
+         "alias" : "GCNumPolicyDeclined",
+         "statkey" : "GCNumPolicyDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined du to non-availability of required resources.",
+         "units" : "default",
+         "alias" : "GCNumResDeclined",
+         "statkey" : "GCNumResDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Connections which are in the process of being setup.",
+         "units" : "default",
+         "alias" : "GCNumHalfOpen",
+         "statkey" : "GCNumHalfOpen",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are currently active.",
+         "units" : "default",
+         "alias" : "GCNumActive",
+         "statkey" : "GCNumActive",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Connections which were active but which were since normally terminated.",
+         "units" : "default",
+         "alias" : "GCNumExpired",
+         "statkey" : "GCNumExpired",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Connections which were active but which were aborted due to reasons of policy or resource rationing.",
+         "units" : "default",
+         "alias" : "GCNumAborted",
+         "statkey" : "GCNumAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Embryonic application layer connections",
+         "units" : "default",
+         "alias" : "GCNumEmbryonic",
+         "statkey" : "GCNumEmbryonic",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last minute.",
+         "units" : "default",
+         "alias" : "GCSetupRate1",
+         "statkey" : "GCSetupRate1",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last 5 minutes.",
+         "units" : "default",
+         "alias" : "GCSetupRate5",
+         "statkey" : "GCSetupRate5",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Active connections which correspond to remote access applications(PPP, PPTP, L2TP, IPSEC).",
+         "units" : "default",
+         "alias" : "GCNumRemoteAccess",
+         "statkey" : "GCNumRemoteAccess",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are attempted to be set up.",
+         "units" : "default",
+         "alias" : "ICMP_NumAttempted",
+         "statkey" : "ICMP_NumAttempted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were aborted.",
+         "units" : "default",
+         "alias" : "ICMP_NumSetupsAborted",
+         "statkey" : "ICMP_NumSetupsAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined due to security.",
+         "units" : "default",
+         "alias" : "ICMP_NumPolicyDeclined",
+         "statkey" : "ICMP_NumPolicyDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined du to non-availability of required resources.",
+         "units" : "default",
+         "alias" : "ICMP_NumResDeclined",
+         "statkey" : "ICMP_NumResDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Connections which are in the process of being setup.",
+         "units" : "default",
+         "alias" : "ICMP_NumHalfOpen",
+         "statkey" : "ICMP_NumHalfOpen",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are currently active.",
+         "units" : "default",
+         "alias" : "ICMP_NumActive",
+         "statkey" : "ICMP_NumActive",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Connections which were active but which were since normally terminated.",
+         "units" : "default",
+         "alias" : "ICMP_NumExpired",
+         "statkey" : "ICMP_NumExpired",
+         "datatype" : "float"
+      },
+      {
+         "description" : "connections which were active but which were aborted due to reasons of policy or resource rationing",
+         "units" : "default",
+         "alias" : "ICMP_NumAborted",
+         "statkey" : "ICMP_NumAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last minute",
+         "units" : "default",
+         "alias" : "ICMP_SetupRate1",
+         "statkey" : "ICMP_SetupRate1",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last 5 minutes",
+         "units" : "default",
+         "alias" : "ICMP_SetupRate5",
+         "statkey" : "ICMP_SetupRate5",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are attempted to be set up.",
+         "units" : "default",
+         "alias" : "TCP_NumAttempted",
+         "statkey" : "TCP_NumAttempted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were aborted.",
+         "units" : "default",
+         "alias" : "TCP_NumSetupsAborted",
+         "statkey" : "TCP_NumSetupsAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined due to security.",
+         "units" : "default",
+         "alias" : "TCP_NumPolicyDeclined",
+         "statkey" : "TCP_NumPolicyDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined du to non-availability of required resources.",
+         "units" : "default",
+         "alias" : "TCP_NumResDeclined",
+         "statkey" : "TCP_NumResDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Connections which are in the process of being setup.",
+         "units" : "default",
+         "alias" : "TCP_NumHalfOpen",
+         "statkey" : "TCP_NumHalfOpen",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are currently active.",
+         "units" : "default",
+         "alias" : "TCP_NumActive",
+         "statkey" : "TCP_NumActive",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Connections which were active but which were since normally terminated.",
+         "units" : "default",
+         "alias" : "TCP_NumExpired",
+         "statkey" : "TCP_NumExpired",
+         "datatype" : "float"
+      },
+      {
+         "description" : "connections which were active but which were aborted due to reasons of policy or resource rationing",
+         "units" : "default",
+         "alias" : "TCP_NumAborted",
+         "statkey" : "TCP_NumAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last minute",
+         "units" : "default",
+         "alias" : "TCP_SetupRate1",
+         "statkey" : "TCP_SetupRate1",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last 5 minutes",
+         "units" : "default",
+         "alias" : "TCP_SetupRate5",
+         "statkey" : "TCP_SetupRate5",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are attempted to be set up.",
+         "units" : "default",
+         "alias" : "UDP_NumAttempted",
+         "statkey" : "UDP_NumAttempted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were aborted.",
+         "units" : "default",
+         "alias" : "UDP_NumSetupsAborted",
+         "statkey" : "UDP_NumSetupsAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined due to security.",
+         "units" : "default",
+         "alias" : "UDP_NumPolicyDeclined",
+         "statkey" : "UDP_NumPolicyDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined du to non-availability of required resources.",
+         "units" : "default",
+         "alias" : "UDP_NumResDeclined",
+         "statkey" : "UDP_NumResDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Connections which are in the process of being setup.",
+         "units" : "default",
+         "alias" : "UDP_NumHalfOpen",
+         "statkey" : "UDP_NumHalfOpen",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are currently active.",
+         "units" : "default",
+         "alias" : "UDP_NumActive",
+         "statkey" : "UDP_NumActive",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Connections which were active but which were since normally terminated.",
+         "units" : "default",
+         "alias" : "UDP_NumExpired",
+         "statkey" : "UDP_NumExpired",
+         "datatype" : "float"
+      },
+      {
+         "description" : "connections which were active but which were aborted due to reasons of policy or resource rationing",
+         "units" : "default",
+         "alias" : "UDP_NumAborted",
+         "statkey" : "UDP_NumAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last minute",
+         "units" : "default",
+         "alias" : "UDP_SetupRate1",
+         "statkey" : "UDP_SetupRate1",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last 5 minutes",
+         "units" : "default",
+         "alias" : "UDP_SetupRate5",
+         "statkey" : "UDP_SetupRate5",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are attempted to be set up.",
+         "units" : "default",
+         "alias" : "HTTP_NumAttempted",
+         "statkey" : "HTTP_NumAttempted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were aborted.",
+         "units" : "default",
+         "alias" : "HTTP_NumSetupsAborted",
+         "statkey" : "HTTP_NumSetupsAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined due to security.",
+         "units" : "default",
+         "alias" : "HTTP_NumPolicyDeclined",
+         "statkey" : "HTTP_NumPolicyDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined du to non-availability of required resources.",
+         "units" : "default",
+         "alias" : "HTTP_NumResDeclined",
+         "statkey" : "HTTP_NumResDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Connections which are in the process of being setup.",
+         "units" : "default",
+         "alias" : "HTTP_NumHalfOpen",
+         "statkey" : "HTTP_NumHalfOpen",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are currently active.",
+         "units" : "default",
+         "alias" : "HTTP_NumActive",
+         "statkey" : "HTTP_NumActive",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Connections which were active but which were since normally terminated.",
+         "units" : "default",
+         "alias" : "HTTP_NumExpired",
+         "statkey" : "HTTP_NumExpired",
+         "datatype" : "float"
+      },
+      {
+         "description" : "connections which were active but which were aborted due to reasons of policy or resource rationing",
+         "units" : "default",
+         "alias" : "HTTP_NumAborted",
+         "statkey" : "HTTP_NumAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last minute",
+         "units" : "default",
+         "alias" : "HTTP_SetupRate1",
+         "statkey" : "HTTP_SetupRate1",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last 5 minutes",
+         "units" : "default",
+         "alias" : "HTTP_SetupRate5",
+         "statkey" : "HTTP_SetupRate5",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are attempted to be set up.",
+         "units" : "default",
+         "alias" : "HTTPS_NumAttempted",
+         "statkey" : "HTTPS_NumAttempted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were aborted.",
+         "units" : "default",
+         "alias" : "HTTPS_NumSetupsAborted",
+         "statkey" : "HTTPS_NumSetupsAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined due to security.",
+         "units" : "default",
+         "alias" : "HTTPS_NumPolicyDeclined",
+         "statkey" : "HTTPS_NumPolicyDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined du to non-availability of required resources.",
+         "units" : "default",
+         "alias" : "HTTPS_NumResDeclined",
+         "statkey" : "HTTPS_NumResDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Connections which are in the process of being setup.",
+         "units" : "default",
+         "alias" : "HTTPS_NumHalfOpen",
+         "statkey" : "HTTPS_NumHalfOpen",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are currently active.",
+         "units" : "default",
+         "alias" : "HTTPS_NumActive",
+         "statkey" : "HTTPS_NumActive",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Connections which were active but which were since normally terminated.",
+         "units" : "default",
+         "alias" : "HTTPS_NumExpired",
+         "statkey" : "HTTPS_NumExpired",
+         "datatype" : "float"
+      },
+      {
+         "description" : "connections which were active but which were aborted due to reasons of policy or resource rationing",
+         "units" : "default",
+         "alias" : "HTTPS_NumAborted",
+         "statkey" : "HTTPS_NumAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last minute",
+         "units" : "default",
+         "alias" : "HTTPS_SetupRate1",
+         "statkey" : "HTTPS_SetupRate1",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last 5 minutes",
+         "units" : "default",
+         "alias" : "HTTPS_SetupRate5",
+         "statkey" : "HTTPS_SetupRate5",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are attempted to be set up.",
+         "units" : "default",
+         "alias" : "DNS_NumAttempted",
+         "statkey" : "DNS_NumAttempted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were aborted.",
+         "units" : "default",
+         "alias" : "DNS_NumSetupsAborted",
+         "statkey" : "DNS_NumSetupsAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined due to security.",
+         "units" : "default",
+         "alias" : "DNS_NumPolicyDeclined",
+         "statkey" : "DNS_NumPolicyDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Number of connection setup attempts that were declined du to non-availability of required resources.",
+         "units" : "default",
+         "alias" : "DNS_NumResDeclined",
+         "statkey" : "DNS_NumResDeclined",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Connections which are in the process of being setup.",
+         "units" : "default",
+         "alias" : "DNS_NumHalfOpen",
+         "statkey" : "DNS_NumHalfOpen",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Number of connections which are currently active.",
+         "units" : "default",
+         "alias" : "DNS_NumActive",
+         "statkey" : "DNS_NumActive",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Connections which were active but which were since normally terminated.",
+         "units" : "default",
+         "alias" : "DNS_NumExpired",
+         "statkey" : "DNS_NumExpired",
+         "datatype" : "float"
+      },
+      {
+         "description" : "connections which were active but which were aborted due to reasons of policy or resource rationing",
+         "units" : "default",
+         "alias" : "DNS_NumAborted",
+         "statkey" : "DNS_NumAborted",
+         "datatype" : "float"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last minute",
+         "units" : "default",
+         "alias" : "DNS_SetupRate1",
+         "statkey" : "DNS_SetupRate1",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "Averaged number of connections establishing per second over the last 5 minutes",
+         "units" : "default",
+         "alias" : "DNS_SetupRate5",
+         "statkey" : "DNS_SetupRate5",
+         "datatype" : "bigint"
+      }
+   ],
+   "chart" : [
+      {
+         "title" : "Global Connection Events",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "GCNumAttempted",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "GCNumSetupsAborted",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "GCNumPolicyDeclined",
+                  "color" : "#FF0000"
+               },
+               {
+                  "name" : "GCNumResDeclined",
+                  "color" : "#990000"
+               },
+               {
+                  "name" : "GCNumExpired",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "GCNumAborted",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Events/s"
+         },
+         "id" : "1"
+      },
+      {
+         "title" : "Global Connection Statistics",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "GCNumActive",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "GCNumHalfOpen",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "GCNumEmbryonic",
+                  "color" : "#FF0000"
+               },
+               {
+                  "name" : "GCNumRemoteAccess",
+                  "color" : "#990000"
+               },
+               {
+                  "name" : "GCSetupRate1",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "GCSetupRate5",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Connections"
+         },
+         "id" : "2"
+      },
+      {
+         "title" : "ICMP Connection Events",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "ICMP_NumAttempted",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "ICMP_NumSetupsAborted",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "ICMP_NumPolicyDeclined",
+                  "color" : "#FF0000"
+               },
+               {
+                  "name" : "ICMP_NumResDeclined",
+                  "color" : "#990000"
+               },
+               {
+                  "name" : "ICMP_NumExpired",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "ICMP_NumAborted",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Events/s"
+         },
+         "id" : "3"
+      },
+      {
+         "title" : "ICMP Connection Statistics",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "ICMP_NumActive",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "ICMP_NumHalfOpen",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "ICMP_SetupRate1",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "ICMP_SetupRate5",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Connections"
+         },
+         "id" : "4"
+      },
+      {
+         "title" : "TCP Connection Events",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "TCP_NumAttempted",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "TCP_NumSetupsAborted",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "TCP_NumPolicyDeclined",
+                  "color" : "#FF0000"
+               },
+               {
+                  "name" : "TCP_NumResDeclined",
+                  "color" : "#990000"
+               },
+               {
+                  "name" : "TCP_NumExpired",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "TCP_NumAborted",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Events/s"
+         },
+         "id" : "5"
+      },
+      {
+         "title" : "TCP Connection Statistics",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "TCP_NumActive",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "TCP_NumHalfOpen",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "TCP_SetupRate1",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "TCP_SetupRate5",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Connections"
+         },
+         "id" : "6"
+      },
+      {
+         "title" : "UDP Connection Events",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "UDP_NumAttempted",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "UDP_NumSetupsAborted",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "UDP_NumPolicyDeclined",
+                  "color" : "#FF0000"
+               },
+               {
+                  "name" : "UDP_NumResDeclined",
+                  "color" : "#990000"
+               },
+               {
+                  "name" : "UDP_NumExpired",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "UDP_NumAborted",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Events/s"
+         },
+         "id" : "7"
+      },
+      {
+         "title" : "UDP Connection Statistics",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "UDP_NumActive",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "UDP_NumHalfOpen",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "UDP_SetupRate1",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "UDP_SetupRate5",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Connections"
+         },
+         "id" : "8"
+      },
+      {
+         "title" : "HTTP Connection Events",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "HTTP_NumAttempted",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "HTTP_NumSetupsAborted",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "HTTP_NumPolicyDeclined",
+                  "color" : "#FF0000"
+               },
+               {
+                  "name" : "HTTP_NumResDeclined",
+                  "color" : "#990000"
+               },
+               {
+                  "name" : "HTTP_NumExpired",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "HTTP_NumAborted",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Events/s"
+         },
+         "id" : "9"
+      },
+      {
+         "title" : "HTTP Connection Statistics",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "HTTP_NumActive",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "HTTP_NumHalfOpen",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "HTTP_SetupRate1",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "HTTP_SetupRate5",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Connections"
+         },
+         "id" : "10"
+      },
+      {
+         "title" : "HTTPS Connection Events",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "HTTPS_NumAttempted",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "HTTPS_NumSetupsAborted",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "HTTPS_NumPolicyDeclined",
+                  "color" : "#FF0000"
+               },
+               {
+                  "name" : "HTTPS_NumResDeclined",
+                  "color" : "#990000"
+               },
+               {
+                  "name" : "HTTPS_NumExpired",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "HTTPS_NumAborted",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Events/s"
+         },
+         "id" : "11"
+      },
+      {
+         "title" : "HTTPS Connection Statistics",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "HTTPS_NumActive",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "HTTPS_NumHalfOpen",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "HTTPS_SetupRate1",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "HTTPS_SetupRate5",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Connections"
+         },
+         "id" : "12"
+      },
+      {
+         "title" : "DNS Connection Events",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "DNS_NumAttempted",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "DNS_NumSetupsAborted",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "DNS_NumPolicyDeclined",
+                  "color" : "#FF0000"
+               },
+               {
+                  "name" : "DNS_NumResDeclined",
+                  "color" : "#990000"
+               },
+               {
+                  "name" : "DNS_NumExpired",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "DNS_NumAborted",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Events/s"
+         },
+         "id" : "13"
+      },
+      {
+         "title" : "DNS Connection Statistics",
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "DNS_NumActive",
+                  "color" : "#339900"
+               },
+               {
+                  "name" : "DNS_NumHalfOpen",
+                  "color" : "#666666"
+               },
+               {
+                  "name" : "DNS_SetupRate1",
+                  "color" : "#cc3399"
+               },
+               {
+                  "name" : "DNS_SetupRate5",
+                  "color" : "#9933cc"
+               }
+            ],
+            "units" : "default",
+            "ylabel" : "Connections"
+         },
+         "id" : "14"
+      }
+   ],
+   "plugin" : {
+      "datatype" : "statistic",
+      "command" : "check-snmp-cisco-fw",
+      "prefer" : "localhost",
+      "description" : "Monitor the firewall of a Cisco Router.",
+      "abstract" : "Cisco Firewall check",
+      "plugin" : "SNMP.Cisco.Fw",
+      "id" : "10008",
+      "info" : {
+         "examples" : [
+            {
+               "command_line" : "check-snmp-cisco-fw --warning 'GCNumEmbryonic:lt:6' --critical 'GCSetupRate1:ge:2000'",
+               "arguments" : [
+                  "warning",
+                  "GCNumEmbryonic:lt:6",
+                  "critical",
+                  "GCSetupRate1:ge:2000"
+               ],
+               "description" : [
+                  "A simple example to check the connection state and trigger a warning if Embryonic application layer connections is lower than 6 or trigger a critical if the connection setup rate is higher than 2000 per minute:"
+               ]
+            }
+         ],
+         "flags" : "",
+         "version" : "0.1",
+         "thresholds" : {
+            "options" : [
+               {
+                  "unit" : "bytes",
+                  "key" : "GCNumAttempted"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "GCNumSetupsAborted"
+               },
+               {
+                  "key" : "GCNumPolicyDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "GCNumResDeclined"
+               },			   
+               {
+                  "key" : "GCNumHalfOpen",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "GCNumActive",
+                  "unit" : "bytes"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "GCNumExpired"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "GCNumAborted"
+               },
+               {
+                  "key" : "GCNumEmbryonic",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "GCSetupRate1",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "GCSetupRate5",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "GCNumRemoteAccess",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_NumAttempted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_NumSetupsAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_NumPolicyDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_NumResDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_NumHalfOpen",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_NumActive",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_NumExpired",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_NumAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_SetupRate1",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "ICMP_SetupRate5",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_NumAttempted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_NumSetupsAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_NumPolicyDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_NumResDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_NumHalfOpen",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_NumActive",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_NumExpired",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_NumAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_SetupRate1",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "TCP_SetupRate5",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_NumAttempted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_NumSetupsAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_NumPolicyDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_NumResDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_NumHalfOpen",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_NumActive",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_NumExpired",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_NumAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_SetupRate1",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "UDP_SetupRate5",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_NumAttempted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_NumSetupsAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_NumPolicyDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_NumResDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_NumHalfOpen",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_NumActive",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_NumExpired",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_NumAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_SetupRate1",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTP_SetupRate5",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_NumAttempted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_NumSetupsAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_NumPolicyDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_NumResDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_NumHalfOpen",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_NumActive",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_NumExpired",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_NumAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_SetupRate1",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "HTTPS_SetupRate5",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_NumAttempted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_NumSetupsAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_NumPolicyDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_NumResDeclined",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_NumHalfOpen",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_NumActive",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_NumExpired",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_NumAborted",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_SetupRate1",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "DNS_SetupRate5",
+                  "unit" : "bytes"
+               }
+            ],
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "bytes or percent",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for bytes:\n\n",
+               "    KB = Kilobytes   TB = Terabytes   ZB = Zettabytes\n",
+               "    MB = Megabytes   PB = Petabytes   YB = Yottabytes\n",
+               "    GB = Gigabytes   EB = Exabytes\n\n",
+               "  Allowed units for percent: %\n\n"
+            ]
+         },
+         "plugin" : "check-snmp-cisco-fw",
+         "options" : [
+            {
+               "value_desc" : "hostname or ip address",
+               "value_type" : "string",
+               "description" : "A hostname or IP address to connect to.",
+               "name" : "Hostname or IP address",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "option" : "host",
+               "default" : "127.0.0.1"
+            },
+            {
+               "option" : "port",
+               "mandatory" : 0,
+               "default" : 161,
+               "name" : "Port number",
+               "description" : "A port number to connect to.",
+               "value_type" : "int",
+               "value_desc" : "port",
+               "multiple" : 0
+            },
+            {
+               "multiple" : 0,
+               "name" : "SNMP community",
+               "description" : "The SNMP community to connect to the host.",
+               "value_type" : "string",
+               "value_desc" : "community",
+               "default" : "public",
+               "option" : "community",
+               "mandatory" : 0
+            },
+            {
+               "default" : 2,
+               "mandatory" : 0,
+               "option" : "snmp-version",
+               "multiple" : 0,
+               "description" : "The SNMP version to use to connect to the host.",
+               "name" : "SNMP version",
+               "value_desc" : "version",
+               "value_type" : "string"
+            },
+            {
+               "value_desc" : "username",
+               "value_type" : "string",
+               "description" : "The SNMPv3 username.",
+               "name" : "SNMPv3 username",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "option" : "username",
+               "default" : null
+            },
+            {
+               "multiple" : 0,
+               "value_type" : "string",
+               "value_desc" : "authkey",
+               "name" : "SNMPv3 auth key",
+               "description" : "The SNMPv3 auth key.",
+               "default" : null,
+               "option" : "authkey",
+               "mandatory" : 0
+            },
+            {
+               "default" : null,
+               "option" : "authpassword",
+               "mandatory" : 0,
+               "multiple" : 0,
+               "name" : "SNMPv3 auth password",
+               "description" : "The SNMPv3 auth password.",
+               "value_type" : "string",
+               "value_desc" : "authpassword"
+            },
+            {
+               "default" : null,
+               "mandatory" : 0,
+               "option" : "authprotocol",
+               "multiple" : 0,
+               "description" : "The SNMPv3 auth protocol.",
+               "name" : "SNMPv3 auth protocol",
+               "value_desc" : "authprotocol",
+               "value_type" : "string"
+            },
+            {
+               "multiple" : 0,
+               "description" : "The SNMPv3 priv key.",
+               "name" : "SNMPv3 priv key",
+               "value_desc" : "privkey",
+               "value_type" : "string",
+               "default" : null,
+               "mandatory" : 0,
+               "option" : "privkey"
+            },
+            {
+               "multiple" : 0,
+               "value_desc" : "privpassword",
+               "value_type" : "string",
+               "description" : "The SNMPv3 priv password.",
+               "name" : "SNMPv3 priv password",
+               "default" : null,
+               "mandatory" : 0,
+               "option" : "privpassword"
+            },
+            {
+               "multiple" : 0,
+               "name" : "SNMPv3 priv protocol",
+               "description" : "The SNMPv3 priv protocol.",
+               "value_type" : "string",
+               "value_desc" : "privprotocol",
+               "default" : null,
+               "option" : "privprotocol",
+               "mandatory" : 0
+            },
+            {
+               "mandatory" : 0,
+               "option" : "warning",
+               "default" : null,
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "name" : "Warning threshold",
+               "value_desc" : "key:value or key:op:value",
+               "value_type" : "string",
+               "multiple" : 1
+            },
+            {
+               "option" : "critical",
+               "mandatory" : 0,
+               "default" : null,
+               "name" : "Critical threshold",
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "value_type" : "string",
+               "value_desc" : "key:value or key:op:value",
+               "multiple" : 1
+            }
+         ]
+      },
+      "netaccess" : "yes",
+      "category" : "System,SNMP"
+   }
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-cisco-ios-system-stats
+++ b/plugins/snmp/Configs/Import/plugin-snmp-cisco-ios-system-stats
@@ -1,0 +1,525 @@
+{
+   "plugin" : {
+      "netaccess" : "yes",
+      "description" : "Monitor CPU and memory statistics of a Cisco IOS device",
+      "datatype" : "statistic",
+      "category" : "Network,SNMP",
+      "prefer" : "localhost",
+      "info" : {
+         "examples" : [
+            {
+               "command_line" : "check-snmp-cisco-ios-system-stats --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "arguments" : [
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ],
+               "description" : [
+                  "CPU and memory statistics of a Cisco IOS device:"
+               ]
+            }
+         ],
+         "flags" : "",
+         "version" : "0.1",
+         "thresholds" : {
+            "options" : [
+               {
+                  "key" : "CPUTotal5sec",
+                  "unit" : "percent"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "CPUTotal1min"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "CPUTotal5min"
+               },
+               {
+                  "key" : "CPUInterrupt",
+                  "unit" : "percent"
+               },
+               {
+                  "key" : "CPUMemUsed",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "CPUMemFree",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "CPUMemLargestFree",
+                  "unit" : "bytes"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "IOMemUsed"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "IOMemFree"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "IOMemLargestFree"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "CPUMemUsedPercent"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "CPUMemFreePercent"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "IOMemUsedPercent"
+               },
+               {
+                  "key" : "IOMemFreePercent",
+                  "unit" : "percent"
+               }
+            ],
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "percent or bytes",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for percent: %\n\n",
+               "  Allowed units for bytes:\n\n",
+               "    KB = Kilobytes   TB = Terabytes   ZB = Zettabytes\n",
+               "    MB = Megabytes   PB = Petabytes   YB = Yottabytes\n",
+               "    GB = Gigabytes   EB = Exabytes\n\n"
+            ]
+         },
+         "options" : [
+            {
+               "name" : "Hostname or IP address",
+               "value_desc" : "hostname or ip address",
+               "mandatory" : 0,
+               "value_type" : "string",
+               "description" : "A hostname or IP address to connect to.",
+               "option" : "host",
+               "multiple" : 0,
+               "default" : "127.0.0.1"
+            },
+            {
+               "multiple" : 0,
+               "default" : 161,
+               "value_type" : "int",
+               "description" : "A port number to connect to.",
+               "option" : "port",
+               "value_desc" : "port",
+               "name" : "Port number",
+               "mandatory" : 0
+            },
+            {
+               "multiple" : 0,
+               "default" : "public",
+               "name" : "SNMP community",
+               "mandatory" : 0,
+               "value_desc" : "community",
+               "value_type" : "string",
+               "option" : "community",
+               "description" : "The SNMP community to connect to the host."
+            },
+            {
+               "multiple" : 0,
+               "default" : 2,
+               "value_type" : "string",
+               "description" : "The SNMP version to use to connect to the host.",
+               "option" : "snmp-version",
+               "name" : "SNMP version",
+               "value_desc" : "version",
+               "mandatory" : 0
+            },
+            {
+               "name" : "SNMPv3 username",
+               "mandatory" : 0,
+               "value_desc" : "username",
+               "value_type" : "string",
+               "description" : "The SNMPv3 username.",
+               "option" : "username",
+               "multiple" : 0,
+               "default" : null
+            },
+            {
+               "default" : null,
+               "multiple" : 0,
+               "value_desc" : "authkey",
+               "name" : "SNMPv3 auth key",
+               "mandatory" : 0,
+               "description" : "The SNMPv3 auth key.",
+               "option" : "authkey",
+               "value_type" : "string"
+            },
+            {
+               "default" : null,
+               "multiple" : 0,
+               "description" : "The SNMPv3 auth password.",
+               "option" : "authpassword",
+               "value_type" : "string",
+               "value_desc" : "authpassword",
+               "mandatory" : 0,
+               "name" : "SNMPv3 auth password"
+            },
+            {
+               "default" : null,
+               "multiple" : 0,
+               "name" : "SNMPv3 auth protocol",
+               "mandatory" : 0,
+               "value_desc" : "authprotocol",
+               "option" : "authprotocol",
+               "description" : "The SNMPv3 auth protocol.",
+               "value_type" : "string"
+            },
+            {
+               "multiple" : 0,
+               "default" : null,
+               "name" : "SNMPv3 priv key",
+               "value_desc" : "privkey",
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "privkey",
+               "description" : "The SNMPv3 priv key."
+            },
+            {
+               "default" : null,
+               "multiple" : 0,
+               "name" : "SNMPv3 priv password",
+               "mandatory" : 0,
+               "value_desc" : "privpassword",
+               "description" : "The SNMPv3 priv password.",
+               "option" : "privpassword",
+               "value_type" : "string"
+            },
+            {
+               "multiple" : 0,
+               "default" : null,
+               "value_type" : "string",
+               "description" : "The SNMPv3 priv protocol.",
+               "option" : "privprotocol",
+               "name" : "SNMPv3 priv protocol",
+               "value_desc" : "privprotocol",
+               "mandatory" : 0
+            },
+            {
+               "default" : null,
+               "multiple" : 1,
+               "name" : "Warning threshold",
+               "mandatory" : 0,
+               "value_desc" : "key:value or key:op:value",
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "option" : "warning",
+               "value_type" : "string"
+            },
+            {
+               "mandatory" : 0,
+               "name" : "Critical threshold",
+               "value_desc" : "key:value or key:op:value",
+               "option" : "critical",
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "value_type" : "string",
+               "default" : null,
+               "multiple" : 1
+            }
+         ],
+         "plugin" : "check-snmp-cisco-ios-system-stats"
+      },
+      "id" : "10011",
+      "command" : "check-snmp-cisco-ios-system-stats",
+      "abstract" : "Cisco IOS CPU & Memory",
+      "plugin" : "SNMP.CISCO.IOS.SysStats"
+   },
+   "chart" : [
+      {
+         "id" : "1",
+         "options" : {
+            "chart-type" : "line",
+            "units" : "percent",
+            "series" : [
+               {
+                  "color" : "#005467",
+                  "name" : "CPUTotal5sec"
+               },
+               {
+                  "color" : "#ffb244",
+                  "name" : "CPUTotal1min"
+               },
+               {
+                  "color" : "#2ba743",
+                  "name" : "CPUTotal5min"
+               }
+            ],
+            "ylabel" : "percent"
+         },
+         "title" : "CPU Load"
+      },
+      {
+         "id" : "2",
+         "title" : "CPU avg 5sec - and interrupt load",
+         "options" : {
+            "series" : [
+               {
+                  "color" : "#005467",
+                  "name" : "CPUTotal5sec"
+               },
+               {
+                  "color" : "#ffb244",
+                  "name" : "CPUInterrupt"
+               }
+            ],
+            "chart-type" : "line",
+            "units" : "percent",
+            "ylabel" : "percent"
+         }
+      },
+      {
+         "id" : "3",
+         "options" : {
+            "units" : "percent",
+            "chart-type" : "area",
+            "series" : [
+               {
+                  "color" : "#005467",
+                  "name" : "IOMemFreePercent"
+               },
+               {
+                  "name" : "IOMemUsedPercent",
+                  "color" : "#ffb244"
+               }
+            ],
+            "ylabel" : "percent"
+         },
+         "title" : "IO Memory Pool Utilization"
+      },
+      {
+         "id" : "4",
+         "title" : "Processor Memory Pool Utilization",
+         "options" : {
+            "series" : [
+               {
+                  "name" : "CPUMemFreePercent",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "CPUMemUsedPercent",
+                  "color" : "#ffb244"
+               }
+            ],
+            "units" : "percent",
+            "chart-type" : "area",
+            "ylabel" : "percent"
+         }
+      },
+      {
+         "id" : "5",
+         "title" : "IO Memory Pool Usage",
+         "options" : {
+            "ylabel" : "bytes",
+            "units" : "bytes",
+            "chart-type" : "area",
+            "series" : [
+               {
+                  "name" : "IOMemFree",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "IOMemUsed",
+                  "color" : "#ffb244"
+               }
+            ]
+         }
+      },
+      {
+         "title" : "Processor Memory Pool Usage",
+         "options" : {
+            "ylabel" : "bytes",
+            "units" : "bytes",
+            "chart-type" : "area",
+            "series" : [
+               {
+                  "color" : "#005467",
+                  "name" : "CPUMemFree"
+               },
+               {
+                  "name" : "CPUMemUsed",
+                  "color" : "#ffb244"
+               }
+            ]
+         },
+         "id" : "6"
+      },
+      {
+         "options" : {
+            "ylabel" : "bytes",
+            "series" : [
+               {
+                  "name" : "IOMemLargestFree",
+                  "color" : "#005467"
+               },
+               {
+                  "color" : "#ffb244",
+                  "name" : "CPUMemLargestFree"
+               }
+            ],
+            "chart-type" : "area",
+            "units" : "bytes"
+         },
+         "title" : "Largest number of free contiguous bytes",
+         "id" : "7"
+      },
+      {
+         "id" : "8",
+         "title" : "Total number of used bytes by memory pools",
+         "options" : {
+            "ylabel" : "bytes",
+            "units" : "bytes",
+            "chart-type" : "area",
+            "series" : [
+               {
+                  "name" : "IOMemTotal",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "CPUMemTotal",
+                  "color" : "#ffb244"
+               }
+            ]
+         }
+      }
+   ],
+   "statistic" : [
+      {
+         "units" : "percent",
+         "statkey" : "CPUInterrupt",
+         "alias" : "CPUInterrupt",
+         "datatype" : "bigint",
+         "description" : "The overall CPU busy percentage in the interrupt context in the last 5 second period"
+      },
+      {
+         "description" : "Free memory of the IO pool in percent",
+         "datatype" : "bigint",
+         "alias" : "IOMemFreePercent",
+         "statkey" : "IOMemFreePercent",
+         "units" : "percent"
+      },
+      {
+         "description" : "Non utilized memory in the IO memory pool",
+         "datatype" : "bigint",
+         "alias" : "IOMemTotal",
+         "statkey" : "IOMemTotal",
+         "units" : "bytes"
+      },
+      {
+         "alias" : "CPUTotal5sec",
+         "datatype" : "bigint",
+         "description" : "The overall CPU busy percentage in the last 5 second period",
+         "units" : "percent",
+         "statkey" : "CPUTotal5sec"
+      },
+      {
+         "description" : "Total memory available in the processor pool",
+         "datatype" : "bigint",
+         "alias" : "CPUMemTotal",
+         "statkey" : "CPUMemTotal",
+         "units" : "bytes"
+      },
+      {
+         "units" : "bytes",
+         "statkey" : "IOMemFree",
+         "alias" : "IOMemFree",
+         "datatype" : "bigint",
+         "description" : "The number of bytes from the IO memory pool that are currently unused"
+      },
+      {
+         "statkey" : "CPUMemFree",
+         "units" : "bytes",
+         "description" : "The number of bytes from the processor memory pool that are currently unused",
+         "alias" : "CPUMemFree",
+         "datatype" : "bigint"
+      },
+      {
+         "alias" : "IOMemUsedPercent",
+         "datatype" : "bigint",
+         "description" : "Utilization of the IO memory pool",
+         "units" : "percent",
+         "statkey" : "IOMemUsedPercent"
+      },
+      {
+         "description" : "The largest number of contiguous bytes from the processor memory pool that are currently unused",
+         "alias" : "CPUMemLargestFree",
+         "datatype" : "bigint",
+         "statkey" : "CPUMemLargestFree",
+         "units" : "bytes"
+      },
+      {
+         "datatype" : "bigint",
+         "alias" : "CPUMemUsed",
+         "description" : "The number of bytes from the processor memory pool that are currently in use",
+         "units" : "bytes",
+         "statkey" : "CPUMemUsed"
+      },
+      {
+         "description" : "The number of bytes from the IO memory pool that are currently in use",
+         "alias" : "IOMemUsed",
+         "datatype" : "bigint",
+         "statkey" : "IOMemUsed",
+         "units" : "bytes"
+      },
+      {
+         "units" : "percent",
+         "statkey" : "CPUMemFreePercent",
+         "alias" : "CPUMemFreePercent",
+         "datatype" : "bigint",
+         "description" : "Non utilized memory in the processor memory pool"
+      },
+      {
+         "description" : "The overall CPU busy percentage in the last 1 minute period",
+         "datatype" : "bigint",
+         "alias" : "CPUTotal1min",
+         "statkey" : "CPUTotal1min",
+         "units" : "percent"
+      },
+      {
+         "units" : "percent",
+         "statkey" : "CPUTotal5min",
+         "alias" : "CPUTotal5min",
+         "datatype" : "bigint",
+         "description" : "The overall CPU busy percentage in the last 5 minute period"
+      },
+      {
+         "units" : "bytes",
+         "statkey" : "IOMemLargestFree",
+         "alias" : "IOMemLargestFree",
+         "datatype" : "bigint",
+         "description" : "The largest number of contiguous bytes from the IO memory pool that are currently unused"
+      },
+      {
+         "units" : "bytes",
+         "statkey" : "CPUMemUsedPercent",
+         "alias" : "CPUMemUsedPercent",
+         "datatype" : "bigint",
+         "description" : "Utilization of the processor memory pool"
+      }
+   ]
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-cpu-linux
+++ b/plugins/snmp/Configs/Import/plugin-snmp-cpu-linux
@@ -1,0 +1,370 @@
+{
+   "chart" : {
+      "options" : {
+         "units" : "null",
+         "ylabel" : "cpu usage in %",
+         "stack" : "true",
+         "series" : [
+            {
+               "color" : "#ffb244",
+               "name" : "system"
+            },
+            {
+               "color" : "#9a72ad",
+               "name" : "user"
+            },
+            {
+               "color" : "#ff0000",
+               "name" : "iowait"
+            },
+            {
+               "name" : "nice",
+               "color" : "#005467"
+            },
+            {
+               "color" : "#2ba743",
+               "name" : "irq"
+            },
+            {
+               "name" : "softirq",
+               "color" : "#7648eb"
+            },
+            {
+               "color" : "#e9644a",
+               "name" : "steal"
+            },
+            {
+               "color" : "#666666",
+               "name" : "guest"
+            },
+            {
+               "color" : "#bf00bf",
+               "name" : "other"
+            }
+         ],
+         "chart-type" : "area"
+      },
+      "id" : "1",
+      "title" : "Linux - cpu usage"
+   },
+   "plugin" : {
+      "abstract" : "CPU check",
+      "plugin" : "SNMP.CPU.Linux",
+      "command" : "check-snmp-cpu-linux",
+      "datatype" : "statistic",
+      "info" : {
+         "options" : [
+            {
+               "multiple" : 0,
+               "description" : "This is the total number of cpu core available on the system If the system uses hyper threading double the sum of all available cores!",
+               "value_type" : "string",
+               "mandatory" : 1,
+               "value_desc" : "cpucount",
+               "name" : "CPU Count",
+               "option" : "cpucount",
+               "default" : null
+            },
+            {
+               "default" : "127.0.0.1",
+               "name" : "Hostname or IP address",
+               "option" : "host",
+               "description" : "A hostname or IP address to connect to.",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "value_desc" : "hostname or ip address",
+               "multiple" : 0
+            },
+            {
+               "option" : "port",
+               "name" : "Port number",
+               "default" : 161,
+               "multiple" : 0,
+               "value_desc" : "port",
+               "description" : "A port number to connect to.",
+               "value_type" : "int",
+               "mandatory" : 0
+            },
+            {
+               "default" : "public",
+               "option" : "community",
+               "name" : "SNMP community",
+               "value_desc" : "community",
+               "mandatory" : 0,
+               "description" : "The SNMP community to connect to the host.",
+               "value_type" : "string",
+               "multiple" : 0
+            },
+            {
+               "name" : "SNMP version",
+               "option" : "snmp-version",
+               "default" : 2,
+               "multiple" : 0,
+               "description" : "The SNMP version to use to connect to the host.",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "value_desc" : "version"
+            },
+            {
+               "option" : "username",
+               "name" : "SNMPv3 username",
+               "default" : null,
+               "multiple" : 0,
+               "value_desc" : "username",
+               "value_type" : "string",
+               "description" : "The SNMPv3 username.",
+               "mandatory" : 0
+            },
+            {
+               "mandatory" : 0,
+               "description" : "The SNMPv3 auth key.",
+               "value_type" : "string",
+               "value_desc" : "authkey",
+               "multiple" : 0,
+               "default" : null,
+               "name" : "SNMPv3 auth key",
+               "option" : "authkey"
+            },
+            {
+               "default" : null,
+               "option" : "authpassword",
+               "name" : "SNMPv3 auth password",
+               "value_desc" : "authpassword",
+               "mandatory" : 0,
+               "description" : "The SNMPv3 auth password.",
+               "value_type" : "string",
+               "multiple" : 0
+            },
+            {
+               "multiple" : 0,
+               "value_desc" : "authprotocol",
+               "description" : "The SNMPv3 auth protocol.",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "option" : "authprotocol",
+               "name" : "SNMPv3 auth protocol",
+               "default" : null
+            },
+            {
+               "multiple" : 0,
+               "value_type" : "string",
+               "description" : "The SNMPv3 priv key.",
+               "mandatory" : 0,
+               "value_desc" : "privkey",
+               "name" : "SNMPv3 priv key",
+               "option" : "privkey",
+               "default" : null
+            },
+            {
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "description" : "The SNMPv3 priv password.",
+               "value_desc" : "privpassword",
+               "name" : "SNMPv3 priv password",
+               "option" : "privpassword",
+               "default" : null
+            },
+            {
+               "option" : "privprotocol",
+               "name" : "SNMPv3 priv protocol",
+               "default" : null,
+               "multiple" : 0,
+               "value_desc" : "privprotocol",
+               "description" : "The SNMPv3 priv protocol.",
+               "value_type" : "string",
+               "mandatory" : 0
+            },
+            {
+               "multiple" : 1,
+               "value_desc" : "key:value or key:op:value",
+               "mandatory" : 0,
+               "value_type" : "string",
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "option" : "warning",
+               "name" : "Warning threshold",
+               "default" : null
+            },
+            {
+               "default" : null,
+               "option" : "critical",
+               "name" : "Critical threshold",
+               "value_desc" : "key:value or key:op:value",
+               "mandatory" : 0,
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "value_type" : "string",
+               "multiple" : 1
+            }
+         ],
+         "thresholds" : {
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "percent",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for percent: %\n\n"
+            ],
+            "options" : [
+               {
+                  "unit" : "percent",
+                  "key" : "user"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "system"
+               },
+               {
+                  "key" : "total",
+                  "unit" : "percent"
+               },
+               {
+                  "key" : "iowait",
+                  "unit" : "percent"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "idle"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "irq"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "softirq"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "steal"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "guest"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "other"
+               }
+            ]
+         },
+         "plugin" : "check-snmp-cpu-linux",
+         "examples" : [
+            {
+               "description" : [
+                  "Monitor the CPU (1.3.6.1.4.1.2021.11) of a Linux System:"
+               ],
+               "arguments" : [
+                  "cpucount",
+                  4,
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ],
+               "command_line" : "check-snmp-cpu-linux --cpucount '4' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'"
+            }
+         ],
+         "flags" : "",
+         "version" : "0.3"
+      },
+      "category" : "Network,SNMP",
+      "id" : "10004",
+      "description" : "Linux CPU statistics SNMP"
+   },
+   "statistic" : [
+      {
+         "statkey" : "user",
+         "description" : "Percentage of CPU utilization at the user level.",
+         "alias" : "User",
+         "datatype" : "float",
+         "units" : "percent"
+      },
+      {
+         "units" : "percent",
+         "statkey" : "nice",
+         "description" : "Time spent in user mode with low priority.",
+         "alias" : "Nice",
+         "datatype" : "float"
+      },
+      {
+         "alias" : "System",
+         "datatype" : "float",
+         "description" : "Percentage of CPU utilization at the system level.",
+         "statkey" : "system",
+         "units" : "percent"
+      },
+      {
+         "units" : "percent",
+         "datatype" : "float",
+         "alias" : "Idle",
+         "statkey" : "idle",
+         "description" : "Percentage of time the CPU is in idle state."
+      },
+      {
+         "units" : "percent",
+         "statkey" : "iowait",
+         "description" : "Percentage of time the CPU is in idle state because an i/o operation is waiting for a disk. This statistic is only available since kernel version 2.5.41.",
+         "alias" : "IOwait",
+         "datatype" : "float"
+      },
+      {
+         "units" : "percent",
+         "alias" : "IRQ",
+         "datatype" : "float",
+         "statkey" : "irq",
+         "description" : "Percentage of time the CPU is servicing interrupts. This statistic is only available since kernel version 2.6.0-test4."
+      },
+      {
+         "units" : "percent",
+         "alias" : "Soft IRQ",
+         "datatype" : "float",
+         "description" : "Percentage of time the CPU is servicing softirqs. This statistic is only available since kernel version 2.6.0-test4.",
+         "statkey" : "softirq"
+      },
+      {
+         "units" : "percent",
+         "description" : "Percentage of stolen CPU time, which is the time spent in other operating systems when running in a virtualized environment. This statistic is only available since kernel version 2.6.11.",
+         "statkey" : "steal",
+         "datatype" : "float",
+         "alias" : "Steal"
+      },
+      {
+         "units" : "percent",
+         "description" : "Percentage of CPU time, which is the time spent running a virtual CPU for guest operating systems under the control of the Linux kernel. This statistic is only available since kernel version 2.6.24.",
+         "statkey" : "guest",
+         "alias" : "Guest",
+         "datatype" : "float"
+      },
+      {
+         "statkey" : "total",
+         "description" : "The total usage of the CPU in percent.",
+         "alias" : "Total",
+         "datatype" : "float",
+         "units" : "percent"
+      },
+      {
+         "datatype" : "float",
+         "alias" : "Other",
+         "statkey" : "other",
+         "description" : "Usage of CPU which don't have counter over snmp",
+         "units" : "percent"
+      }
+   ]
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-ios-proc
+++ b/plugins/snmp/Configs/Import/plugin-snmp-ios-proc
@@ -1,0 +1,366 @@
+{
+   "plugin" : {
+      "description" : "Monitor the process of a Cisco IOS Device.",
+      "datatype" : "statistic",
+      "plugin" : "SNMP.IOS.Process",
+      "command" : "check-snmp-ios-proc",
+      "id" : "10010",
+      "netaccess" : "yes",
+      "abstract" : "Check snmp-ios-proc",
+      "category" : "Network,SNMP",
+      "prefer" : "localhost",
+      "info" : {
+         "version" : "0.3",
+         "examples" : [
+            {
+               "command_line" : "check-snmp-ios-proc --process 'IP Input' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "arguments" : [
+                  "process",
+                  "IP Input",
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ],
+               "description" : [
+                  "Monitor the process of a Cisco IOS Device:"
+               ]
+            }
+         ],
+         "plugin" : "check-snmp-ios-proc",
+         "options" : [
+            {
+               "default" : null,
+               "name" : "Process Name",
+               "value_desc" : "process",
+               "option" : "process",
+               "value_type" : "string",
+               "description" : "This is the process you want to check. The process name should be the full name from 1.3.6.1.4.1.9.9.109.1.2.1.1.2",
+               "mandatory" : 1,
+               "multiple" : 0
+            },
+            {
+               "value_type" : "string",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "description" : "A hostname or IP address to connect to.",
+               "name" : "Hostname or IP address",
+               "value_desc" : "hostname or ip address",
+               "default" : "127.0.0.1",
+               "option" : "host"
+            },
+            {
+               "value_type" : "int",
+               "description" : "A port number to connect to.",
+               "mandatory" : 0,
+               "multiple" : 0,
+               "default" : 161,
+               "name" : "Port number",
+               "value_desc" : "port",
+               "option" : "port"
+            },
+            {
+               "description" : "The SNMP community to connect to the host.",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "community",
+               "default" : "public",
+               "value_desc" : "community",
+               "name" : "SNMP community"
+            },
+            {
+               "default" : 2,
+               "value_desc" : "version",
+               "name" : "SNMP version",
+               "option" : "snmp-version",
+               "value_type" : "string",
+               "description" : "The SNMP version to use to connect to the host.",
+               "mandatory" : 0,
+               "multiple" : 0
+            },
+            {
+               "option" : "username",
+               "name" : "SNMPv3 username",
+               "value_desc" : "username",
+               "default" : null,
+               "multiple" : 0,
+               "mandatory" : 0,
+               "description" : "The SNMPv3 username.",
+               "value_type" : "string"
+            },
+            {
+               "option" : "authkey",
+               "default" : null,
+               "value_desc" : "authkey",
+               "name" : "SNMPv3 auth key",
+               "description" : "The SNMPv3 auth key.",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string"
+            },
+            {
+               "option" : "authpassword",
+               "default" : null,
+               "value_desc" : "authpassword",
+               "name" : "SNMPv3 auth password",
+               "description" : "The SNMPv3 auth password.",
+               "mandatory" : 0,
+               "multiple" : 0,
+               "value_type" : "string"
+            },
+            {
+               "option" : "authprotocol",
+               "default" : null,
+               "name" : "SNMPv3 auth protocol",
+               "value_desc" : "authprotocol",
+               "description" : "The SNMPv3 auth protocol.",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string"
+            },
+            {
+               "option" : "privkey",
+               "name" : "SNMPv3 priv key",
+               "value_desc" : "privkey",
+               "default" : null,
+               "multiple" : 0,
+               "mandatory" : 0,
+               "description" : "The SNMPv3 priv key.",
+               "value_type" : "string"
+            },
+            {
+               "description" : "The SNMPv3 priv password.",
+               "mandatory" : 0,
+               "multiple" : 0,
+               "value_type" : "string",
+               "option" : "privpassword",
+               "default" : null,
+               "value_desc" : "privpassword",
+               "name" : "SNMPv3 priv password"
+            },
+            {
+               "value_type" : "string",
+               "description" : "The SNMPv3 priv protocol.",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "default" : null,
+               "value_desc" : "privprotocol",
+               "name" : "SNMPv3 priv protocol",
+               "option" : "privprotocol"
+            },
+            {
+               "option" : "warning",
+               "name" : "Warning threshold",
+               "value_desc" : "key:value or key:op:value",
+               "default" : null,
+               "mandatory" : 0,
+               "multiple" : 1,
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "value_type" : "string"
+            },
+            {
+               "value_desc" : "key:value or key:op:value",
+               "name" : "Critical threshold",
+               "default" : null,
+               "option" : "critical",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "multiple" : 1,
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information."
+            }
+         ],
+         "flags" : "",
+         "thresholds" : {
+            "options" : [
+               {
+                  "unit" : "bytes",
+                  "key" : "MemAllocated"
+               },
+               {
+                  "key" : "MemFreed",
+                  "unit" : "bytes"
+               },
+               {
+                  "key" : "Invoked",
+                  "unit" : "none"
+               },
+               {
+                  "key" : "Runtime",
+                  "unit" : "none"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "Util5Sec"
+               },
+               {
+                  "key" : "Util1Min",
+                  "unit" : "percent"
+               },
+               {
+                  "unit" : "percent",
+                  "key" : "Util5Min"
+               }
+            ],
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "bytes or percent",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for bytes:\n\n",
+               "    KB = Kilobytes   TB = Terabytes   ZB = Zettabytes\n",
+               "    MB = Megabytes   PB = Petabytes   YB = Yottabytes\n",
+               "    GB = Gigabytes   EB = Exabytes\n\n",
+               "  Allowed units for percent: %\n\n"
+            ]
+         }
+      }
+   },
+   "chart" : [
+      {
+         "options" : {
+            "units" : "percent",
+            "series" : [
+               {
+                  "name" : "Util5Sec",
+                  "color" : "#9a72ad"
+               },
+               {
+                  "color" : "#e9644a",
+                  "name" : "Util1Min"
+               },
+               {
+                  "color" : "#ffb244",
+                  "name" : "Util5Min"
+               }
+            ],
+            "ylabel" : "percent",
+            "chart-type" : "line"
+         },
+         "title" : "SNMP IOS Process Load",
+         "id" : "1"
+      },
+      {
+         "options" : {
+            "ylabel" : "bytes/s",
+            "chart-type" : "area",
+            "series" : [
+               {
+                  "name" : "MemAllocated",
+                  "color" : "#005467"
+               },
+               {
+                  "opposite" : "true",
+                  "name" : "MemFreed",
+                  "color" : "#ff7a0d"
+               }
+            ],
+            "units" : "bytes"
+         },
+         "title" : "SNMP IOS Process Memory",
+         "id" : "2"
+      },
+      {
+         "title" : "SNMP IOS Process Invokes",
+         "id" : "3",
+         "options" : {
+            "chart-type" : "area",
+            "ylabel" : "Invokes/s",
+            "series" : {
+               "color" : "#ffb244",
+               "name" : "Invoked"
+            },
+            "units" : "default"
+         }
+      },
+      {
+         "title" : "SNMP IOS Process Runtime",
+         "id" : "4",
+         "options" : {
+            "series" : {
+               "color" : "#ffb244",
+               "name" : "Runtime"
+            },
+            "chart-type" : "area",
+            "ylabel" : "microseconds",
+            "units" : "default"
+         }
+      }
+   ],
+   "statistic" : [
+      {
+         "units" : "bytes",
+         "alias" : "Priority",
+         "datatype" : "varchar(20)",
+         "statkey" : "Priority",
+         "description" : "The priority level at which the process is running."
+      },
+      {
+         "description" : "A estimate of how busy a process caused the processor to be over a 5 second period.",
+         "units" : "percent",
+         "datatype" : "bigint",
+         "alias" : "Util5Sec",
+         "statkey" : "Util5Sec"
+      },
+      {
+         "description" : "A estimate of how busy a process caused the processor to be over a 1 minute period.",
+         "units" : "percent",
+         "statkey" : "Util1Min",
+         "alias" : "Util1Min",
+         "datatype" : "bigint"
+      },
+      {
+         "description" : "A estimate of how busy a process caused the processor to be over a 5 minutes period.",
+         "units" : "percent",
+         "datatype" : "bigint",
+         "alias" : "Util5Min",
+         "statkey" : "Util5Min"
+      },
+      {
+         "description" : "The sum of all the dynamically allocated memory that this process has received from the system.",
+         "units" : "bytes",
+         "statkey" : "MemAllocated",
+         "alias" : "MemAllocated",
+         "datatype" : "float"
+      },
+      {
+         "description" : "The sum of all memory that this process has returned to the system.",
+         "units" : "bytes",
+         "statkey" : "MemFreed",
+         "datatype" : "float",
+         "alias" : "MemFreed"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "alias" : "Invoked",
+         "statkey" : "Invoked",
+         "description" : "The number of times since cpmTimeCreated that the process has been invoked."
+      },
+      {
+         "description" : "The amount of CPU time the process has used, in microseconds.",
+         "units" : "default",
+         "alias" : "Runtime",
+         "datatype" : "float",
+         "statkey" : "Runtime"
+      }
+   ]
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-nbar
+++ b/plugins/snmp/Configs/Import/plugin-snmp-nbar
@@ -1,0 +1,328 @@
+{
+   "plugin" : {
+      "plugin" : "SNMP.NBAR",
+      "category" : "Network,SNMP",
+      "netaccess" : "yes",
+      "info" : {
+         "version" : "0.3",
+         "examples" : [
+            {
+               "description" : [
+                  "Checks protocol statistics of an interfaces by name"
+               ],
+               "command_line" : "check-snmp-nbar --protocol 'http' --interface 'Di2' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "arguments" : [
+                  "protocol",
+                  "http",
+				  "interface",
+				  "Di2",
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ]
+            },
+            {
+               "arguments" : [
+                  "protocol",
+                  3,
+				  "interface",
+				  33,
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ],
+               "command_line" : "check-snmp-nbar --protocol '3' --interface '33' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "description" : [
+                  "Checks protocol statistics of an interfaces by id"
+               ]
+            }
+         ],
+         "options" : [
+            {
+               "value_type" : "string",
+               "mandatory" : 1,
+               "default" : null,
+               "value_desc" : "interface",
+               "multiple" : 0,
+               "description" : "This is the network interface you want to check.",
+               "option" : "interface",
+               "name" : "Interface"
+            },
+            {
+               "value_type" : "string",
+               "mandatory" : 1,
+               "default" : null,
+               "value_desc" : "Protocol",
+               "multiple" : 0,
+               "description" : "This is the protocol you want to check. For Example http",
+               "option" : "protocol",
+               "name" : "Protocol"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "value_desc" : "hostname or ip address",
+               "default" : "127.0.0.1",
+               "multiple" : 0,
+               "description" : "A hostname or IP address to connect to.",
+               "option" : "host",
+               "name" : "Hostname or IP address"
+            },
+            {
+               "default" : 161,
+               "value_desc" : "port",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "int",
+               "option" : "port",
+               "name" : "Port number",
+               "description" : "A port number to connect to."
+            },
+            {
+               "value_desc" : "community",
+               "default" : "public",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "community",
+               "name" : "SNMP community",
+               "description" : "The SNMP community to connect to the host."
+            },
+            {
+               "description" : "The SNMP version to use to connect to the host.",
+               "name" : "SNMP version",
+               "option" : "snmp-version",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "multiple" : 0,
+               "default" : 2,
+               "value_desc" : "version"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "default" : null,
+               "value_desc" : "username",
+               "multiple" : 0,
+               "description" : "The SNMPv3 username.",
+               "option" : "username",
+               "name" : "SNMPv3 username"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authkey",
+               "description" : "The SNMPv3 auth key.",
+               "name" : "SNMPv3 auth key",
+               "option" : "authkey"
+            },
+            {
+               "name" : "SNMPv3 auth password",
+               "option" : "authpassword",
+               "description" : "The SNMPv3 auth password.",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authpassword",
+               "mandatory" : 0,
+               "value_type" : "string"
+            },
+            {
+               "description" : "The SNMPv3 auth protocol.",
+               "name" : "SNMPv3 auth protocol",
+               "option" : "authprotocol",
+               "mandatory" : 0,
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authprotocol"
+            },
+            {
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "privkey",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "name" : "SNMPv3 priv key",
+               "option" : "privkey",
+               "description" : "The SNMPv3 priv key."
+            },
+            {
+               "default" : null,
+               "value_desc" : "privpassword",
+               "multiple" : 0,
+               "value_type" : "string",
+               "mandatory" : 0,
+               "option" : "privpassword",
+               "name" : "SNMPv3 priv password",
+               "description" : "The SNMPv3 priv password."
+            },
+            {
+               "default" : null,
+               "value_desc" : "privprotocol",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "privprotocol",
+               "name" : "SNMPv3 priv protocol",
+               "description" : "The SNMPv3 priv protocol."
+            },
+            {
+               "option" : "warning",
+               "name" : "Warning threshold",
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "default" : null,
+               "value_desc" : "key:value or key:op:value",
+               "multiple" : 1,
+               "value_type" : "string",
+               "mandatory" : 0
+            },
+            {
+               "name" : "Critical threshold",
+               "option" : "critical",
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "multiple" : 1,
+               "default" : null,
+               "value_desc" : "key:value or key:op:value",
+               "mandatory" : 0,
+               "value_type" : "string"
+            }
+         ],
+         "flags" : "",
+         "plugin" : "check-snmp-nbar",
+         "thresholds" : {
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "bytes",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for bytes:\n\n",
+               "    KB = Kilobytes   TB = Terabytes   ZB = Zettabytes\n",
+               "    MB = Megabytes   PB = Petabytes   YB = Yottabytes\n",
+               "    GB = Gigabytes   EB = Exabytes\n\n"
+            ],
+            "options" : [
+               {
+                  "unit" : "bytes",
+                  "key" : "in_proto_octets"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "out_proto_octets"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "in_proto_pkts"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "out_proto_pkts"
+               }
+            ]
+         }
+      },
+      "description" : "Checks protocol statistics of an interfaces.",
+      "datatype" : "statistic",
+      "id" : "10005",
+      "abstract" : "check-snmp-nbar",
+      "prefer" : "localhost",
+      "command" : "check-snmp-nbar"
+   },
+   "statistic" : [
+      {
+         "units" : "bytes",
+         "datatype" : "float",
+         "description" : "The number of bytes received by the protocol on the interface",
+         "statkey" : "in_proto_octets",
+         "alias" : "in_proto_octets"
+      },
+      {
+         "statkey" : "out_proto_octets",
+         "alias" : "out_proto_octets",
+         "description" : "The number of bytes send by the protocol on the interface",
+         "datatype" : "float",
+         "units" : "bytes"
+      },
+      {
+         "datatype" : "float",
+         "units" : "bytes",
+         "description" : "The number of packets received by the protocol on the interface",
+         "statkey" : "in_proto_pkts",
+         "alias" : "in_proto_pkts"
+      },
+      {
+         "alias" : "out_proto_pkts",
+         "statkey" : "out_proto_pkts",
+         "datatype" : "float",
+         "units" : "bytes",
+         "description" : "The number of packets send by the protocol on the interface"
+      }
+   ],
+   "chart" : [
+      {
+         "options" : {
+            "chart-type" : "area",
+            "series" : [
+               {
+                  "name" : "in_proto_octets",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "out_proto_octets",
+                  "opposite" : "true",
+                  "color" : "#ff7a0d"
+               }
+            ],
+            "ylabel" : "bytes received(+) / send(-)",
+            "units" : "bytes"
+         },
+         "title" : "SNMP NBAR - in/out octets",
+         "id" : "1"
+      },
+      {
+         "title" : "SNMP NBAR - in/out packets",
+         "id" : "2",
+         "options" : {
+            "ylabel" : "packets received(+) / send(-)",
+            "units" : "defaut",
+            "series" : [
+               {
+                  "name" : "in_proto_pkts",
+                  "color" : "#005467"
+               },
+               {
+                  "color" : "#ff7a0d",
+                  "opposite" : "true",
+                  "name" : "out_proto_pkts"
+               }
+            ],
+            "chart-type" : "area"
+         }
+      }
+   ]
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-qos-queue
+++ b/plugins/snmp/Configs/Import/plugin-snmp-qos-queue
@@ -1,0 +1,646 @@
+{
+   "plugin" : {
+      "plugin" : "SNMP.QoS.Queue",
+      "category" : "Network,SNMP",
+      "netaccess" : "yes",
+      "info" : {
+         "version" : "0.1",
+         "examples" : [
+            {
+               "description" : [
+                  "Monitor the Egress QoS queue of interface of a Cisco Switch"
+               ],
+               "command_line" : "check-snmp-qos-queue --interface 'Gi1/0/1' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "arguments" : [
+                  "interface",
+                  "Gi1/0/1",
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ]
+            },
+            {
+               "arguments" : [
+                  "interface",
+                   33,
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ],
+               "command_line" : "check-snmp-qos-queue --interface '10101' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "description" : [
+                  "Monitor the Egress QoS queue of interface of a Cisco Switch"
+               ]
+            }
+         ],
+         "options" : [
+            {
+               "value_type" : "string",
+               "mandatory" : 1,
+               "default" : null,
+               "value_desc" : "interface",
+               "multiple" : 0,
+               "description" : "This is the network interface you want to check.",
+               "option" : "interface",
+               "name" : "Interface"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "value_desc" : "hostname or ip address",
+               "default" : "127.0.0.1",
+               "multiple" : 0,
+               "description" : "A hostname or IP address to connect to.",
+               "option" : "host",
+               "name" : "Hostname or IP address"
+            },
+            {
+               "default" : 161,
+               "value_desc" : "port",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "int",
+               "option" : "port",
+               "name" : "Port number",
+               "description" : "A port number to connect to."
+            },
+            {
+               "value_desc" : "community",
+               "default" : "public",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "community",
+               "name" : "SNMP community",
+               "description" : "The SNMP community to connect to the host."
+            },
+            {
+               "description" : "The SNMP version to use to connect to the host.",
+               "name" : "SNMP version",
+               "option" : "snmp-version",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "multiple" : 0,
+               "default" : 2,
+               "value_desc" : "version"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "default" : null,
+               "value_desc" : "username",
+               "multiple" : 0,
+               "description" : "The SNMPv3 username.",
+               "option" : "username",
+               "name" : "SNMPv3 username"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authkey",
+               "description" : "The SNMPv3 auth key.",
+               "name" : "SNMPv3 auth key",
+               "option" : "authkey"
+            },
+            {
+               "name" : "SNMPv3 auth password",
+               "option" : "authpassword",
+               "description" : "The SNMPv3 auth password.",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authpassword",
+               "mandatory" : 0,
+               "value_type" : "string"
+            },
+            {
+               "description" : "The SNMPv3 auth protocol.",
+               "name" : "SNMPv3 auth protocol",
+               "option" : "authprotocol",
+               "mandatory" : 0,
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authprotocol"
+            },
+            {
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "privkey",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "name" : "SNMPv3 priv key",
+               "option" : "privkey",
+               "description" : "The SNMPv3 priv key."
+            },
+            {
+               "default" : null,
+               "value_desc" : "privpassword",
+               "multiple" : 0,
+               "value_type" : "string",
+               "mandatory" : 0,
+               "option" : "privpassword",
+               "name" : "SNMPv3 priv password",
+               "description" : "The SNMPv3 priv password."
+            },
+            {
+               "default" : null,
+               "value_desc" : "privprotocol",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "privprotocol",
+               "name" : "SNMPv3 priv protocol",
+               "description" : "The SNMPv3 priv protocol."
+            },
+            {
+               "option" : "warning",
+               "name" : "Warning threshold",
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "default" : null,
+               "value_desc" : "key:value or key:op:value",
+               "multiple" : 1,
+               "value_type" : "string",
+               "mandatory" : 0
+            },
+            {
+               "name" : "Critical threshold",
+               "option" : "critical",
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "multiple" : 1,
+               "default" : null,
+               "value_desc" : "key:value or key:op:value",
+               "mandatory" : 0,
+               "value_type" : "string"
+            }
+         ],
+         "flags" : "",
+         "plugin" : "check-snmp-qos-queue",
+         "thresholds" : {
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "bytes",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for bytes:\n\n",
+               "    KB = Kilobytes   TB = Terabytes   ZB = Zettabytes\n",
+               "    MB = Megabytes   PB = Petabytes   YB = Yottabytes\n",
+               "    GB = Gigabytes   EB = Exabytes\n\n"
+            ],
+            "options" : [
+               {
+                  "unit" : "bytes",
+                  "key" : "q1_w1_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q1_w2_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q1_w3_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q2_w1_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q2_w2_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q2_w3_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q3_w1_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q3_w2_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q3_w3_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q4_w1_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q4_w2_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q4_w3_enqueue"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q1_w1_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q1_w2_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q1_w3_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q2_w1_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q2_w2_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q2_w3_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q3_w1_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q3_w2_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q3_w3_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q4_w1_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q4_w2_drop"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "q4_w3_drop"
+               }
+            ]
+         }
+      },
+      "description" : "Monitor the Egress QoS queue of interface of a Cisco Switch",
+      "datatype" : "statistic",
+      "id" : "10006",
+      "abstract" : "check-snmp-qos-queue",
+      "prefer" : "localhost",
+      "command" : "check-snmp-qos-queue"
+   },
+   "statistic" : [
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "description" : "Enqueued packets in queue 1 with weight 1",
+         "statkey" : "q1_w1_enqueue",
+         "alias" : "q1_w1_enqueue"
+      },
+      {
+         "statkey" : "q1_w2_enqueue",
+         "alias" : "q1_w2_enqueue",
+         "description" : "Enqueued packets in queue 1 with weight 2",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "Enqueued packets in queue 1 with weight 3",
+         "statkey" : "q1_w3_enqueue",
+         "alias" : "q1_w3_enqueue"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "description" : "Enqueued packets in queue 2 with weight 1",
+         "statkey" : "q2_w1_enqueue",
+         "alias" : "q2_w1_enqueue"
+      },
+      {
+         "statkey" : "q2_w2_enqueue",
+         "alias" : "q2_w2_enqueue",
+         "description" : "Enqueued packets in queue 2 with weight 2",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "Enqueued packets in queue 2 with weight 3",
+         "statkey" : "q2_w3_enqueue",
+         "alias" : "q2_w3_enqueue"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "description" : "Enqueued packets in queue 3 with weight 1",
+         "statkey" : "q3_w1_enqueue",
+         "alias" : "q3_w1_enqueue"
+      },
+      {
+         "statkey" : "q3_w2_enqueue",
+         "alias" : "q3_w2_enqueue",
+         "description" : "Enqueued packets in queue 3 with weight 2",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "Enqueued packets in queue 3 with weight 3",
+         "statkey" : "q3_w3_enqueue",
+         "alias" : "q3_w3_enqueue"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "description" : "Enqueued packets in queue 3 with weight 1",
+         "statkey" : "q4_w1_enqueue",
+         "alias" : "q4_w1_enqueue"
+      },
+      {
+         "statkey" : "q4_w2_enqueue",
+         "alias" : "q4_w2_enqueue",
+         "description" : "Enqueued packets in queue 3 with weight 2",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "Enqueued packets in queue 3 with weight 3",
+         "statkey" : "q4_w3_enqueue",
+         "alias" : "q4_w3_enqueue"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "description" : "Dropped packets in queue 1 with weight 1",
+         "statkey" : "q1_w1_drop",
+         "alias" : "q1_w1_drop"
+      },
+      {
+         "statkey" : "q1_w2_drop",
+         "alias" : "q1_w2_drop",
+         "description" : "Dropped packets in queue 1 with weight 2",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "Dropped packets in queue 1 with weight 3",
+         "statkey" : "q1_w3_drop",
+         "alias" : "q1_w3_drop"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "description" : "Dropped packets in queue 2 with weight 1",
+         "statkey" : "q2_w1_drop",
+         "alias" : "q2_w1_drop"
+      },
+      {
+         "statkey" : "q2_w2_drop",
+         "alias" : "q2_w2_drop",
+         "description" : "Dropped packets in queue 2 with weight 2",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "Dropped packets in queue 2 with weight 3",
+         "statkey" : "q2_w3_drop",
+         "alias" : "q2_w3_drop"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "description" : "Dropped packets in queue 3 with weight 1",
+         "statkey" : "q3_w1_drop",
+         "alias" : "q3_w1_drop"
+      },
+      {
+         "statkey" : "q3_w2_drop",
+         "alias" : "q3_w2_drop",
+         "description" : "Dropped packets in queue 3 with weight 2",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "Dropped packets in queue 3 with weight 3",
+         "statkey" : "q3_w3_drop",
+         "alias" : "q3_w3_drop"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "description" : "Dropped packets in queue 3 with weight 1",
+         "statkey" : "q4_w1_drop",
+         "alias" : "q4_w1_drop"
+      },
+      {
+         "statkey" : "q4_w2_drop",
+         "alias" : "q4_w2_drop",
+         "description" : "Dropped packets in queue 3 with weight 2",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "Dropped packets in queue 3 with weight 3",
+         "statkey" : "q4_w3_drop",
+         "alias" : "q4_w3_drop"
+      }
+   ],
+   "chart" : [
+      {
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "q1_w1_enqueue",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "q1_w2_enqueue",
+                  "color" : "#ffb244"
+               },
+               {
+                  "name" : "q1_w3_enqueue",
+                  "color" : "#2ba743"
+               },
+               {
+                  "name" : "q1_w1_drop",
+                  "opposite" : "true",
+                  "color" : "#ff7a0d"
+               },
+               {
+                  "name" : "q1_w2_drop",
+                  "opposite" : "true",
+                  "color" : "#e9644a"
+               },
+               {
+                  "name" : "q1_w3_drop",
+                  "opposite" : "true",
+                  "color" : "#9a72ad"
+               }
+            ],
+            "ylabel" : "packets drop(-)  / enqueue(+)",
+            "units" : "default"
+         },
+         "title" : "SNMP QOS QUEUE 1 - enqueue/drop packets",
+         "id" : "1"
+      },
+      {
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "q2_w1_enqueue",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "q2_w2_enqueue",
+                  "color" : "#ffb244"
+               },
+               {
+                  "name" : "q2_w3_enqueue",
+                  "color" : "#2ba743"
+               },
+               {
+                  "name" : "q2_w1_drop",
+                  "opposite" : "true",
+                  "color" : "#ff7a0d"
+               },
+               {
+                  "name" : "q2_w2_drop",
+                  "opposite" : "true",
+                  "color" : "#e9644a"
+               },
+               {
+                  "name" : "q2_w3_drop",
+                  "opposite" : "true",
+                  "color" : "#9a72ad"
+               }
+            ],
+            "ylabel" : "packets drop(-)  / enqueue(+)",
+            "units" : "default"
+         },
+         "title" : "SNMP QOS QUEUE 2 - enqueue/drop packets",
+         "id" : "2"
+      },
+      {
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "q3_w1_enqueue",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "q3_w2_enqueue",
+                  "color" : "#ffb244"
+               },
+               {
+                  "name" : "q3_w3_enqueue",
+                  "color" : "#2ba743"
+               },
+               {
+                  "name" : "q3_w1_drop",
+                  "opposite" : "true",
+                  "color" : "#ff7a0d"
+               },
+               {
+                  "name" : "q3_w2_drop",
+                  "opposite" : "true",
+                  "color" : "#e9644a"
+               },
+               {
+                  "name" : "q3_w3_drop",
+                  "opposite" : "true",
+                  "color" : "#9a72ad"
+               }
+            ],
+            "ylabel" : "packets drop(-)  / enqueue(+)",
+            "units" : "default"
+         },
+         "title" : "SNMP QOS QUEUE 3 - enqueue/drop packets",
+         "id" : "3"
+      },
+      {
+         "options" : {
+            "chart-type" : "line",
+            "series" : [
+               {
+                  "name" : "q4_w1_enqueue",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "q4_w2_enqueue",
+                  "color" : "#ffb244"
+               },
+               {
+                  "name" : "q4_w3_enqueue",
+                  "color" : "#2ba743"
+               },
+               {
+                  "name" : "q4_w1_drop",
+                  "opposite" : "true",
+                  "color" : "#ff7a0d"
+               },
+               {
+                  "name" : "q4_w2_drop",
+                  "opposite" : "true",
+                  "color" : "#e9644a"
+               },
+               {
+                  "name" : "q4_w3_drop",
+                  "opposite" : "true",
+                  "color" : "#9a72ad"
+               }
+            ],
+            "ylabel" : "packets drop(-)  / enqueue(+)",
+            "units" : "default"
+         },
+         "title" : "SNMP QOS QUEUE 4 - enqueue/drop packets",
+         "id" : "4"
+      }
+   ]
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-rmon
+++ b/plugins/snmp/Configs/Import/plugin-snmp-rmon
@@ -1,0 +1,523 @@
+{
+   "plugin" : {
+      "category" : "Network,SNMP",
+      "id" : "10009",
+      "command" : "check-snmp-rmon",
+      "plugin" : "SNMP.RMON",
+      "description" : "Monitor the rmon stats of a interface on a switch",
+      "netaccess" : "yes",
+      "abstract" : "Check snmp-qos-rmon",
+      "info" : {
+         "plugin" : "check-snmp-rmon",
+         "examples" : [
+            {
+               "command_line" : "check-snmp-rmon --interface 'Gi1/0/1' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "description" : [
+                  "Monitor the rmon stats of a interface on a switch:"
+               ],
+               "arguments" : [
+                  "interface",
+                  "Gi1/0/1",
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ]
+            },
+            {
+               "arguments" : [
+                  "interface",
+                  10101,
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ],
+               "command_line" : "check-snmp-rmon --interface '10101' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "description" : [
+                  "Monitor the rmon stats of a interface on a switch:"
+               ]
+            }
+         ],
+         "version" : "0.1",
+         "flags" : "",
+         "options" : [
+            {
+               "value_type" : "string",
+               "default" : null,
+               "name" : "Network interface",
+               "description" : "This is the network interface you want to check. The interface name should the string that is found in ifName (1.3.6.1.2.1.31.1.1.1.1).",
+               "multiple" : 0,
+               "option" : "interface",
+               "mandatory" : 1,
+               "value_desc" : "interface"
+            },
+            {
+               "value_type" : "string",
+               "name" : "Hostname or IP address",
+               "description" : "A hostname or IP address to connect to.",
+               "default" : "127.0.0.1",
+               "multiple" : 0,
+               "option" : "host",
+               "mandatory" : 0,
+               "value_desc" : "hostname or ip address"
+            },
+            {
+               "multiple" : 0,
+               "value_type" : "int",
+               "description" : "A port number to connect to.",
+               "name" : "Port number",
+               "default" : 161,
+               "mandatory" : 0,
+               "value_desc" : "port",
+               "option" : "port"
+            },
+            {
+               "multiple" : 0,
+               "value_type" : "string",
+               "description" : "The SNMP community to connect to the host.",
+               "name" : "SNMP community",
+               "default" : "public",
+               "value_desc" : "community",
+               "mandatory" : 0,
+               "option" : "community"
+            },
+            {
+               "option" : "snmp-version",
+               "value_desc" : "version",
+               "mandatory" : 0,
+               "value_type" : "string",
+               "default" : 2,
+               "name" : "SNMP version",
+               "description" : "The SNMP version to use to connect to the host.",
+               "multiple" : 0
+            },
+            {
+               "multiple" : 0,
+               "value_type" : "string",
+               "default" : null,
+               "name" : "SNMPv3 username",
+               "description" : "The SNMPv3 username.",
+               "mandatory" : 0,
+               "value_desc" : "username",
+               "option" : "username"
+            },
+            {
+               "option" : "authkey",
+               "mandatory" : 0,
+               "value_desc" : "authkey",
+               "default" : null,
+               "name" : "SNMPv3 auth key",
+               "description" : "The SNMPv3 auth key.",
+               "value_type" : "string",
+               "multiple" : 0
+            },
+            {
+               "option" : "authpassword",
+               "value_desc" : "authpassword",
+               "mandatory" : 0,
+               "name" : "SNMPv3 auth password",
+               "default" : null,
+               "description" : "The SNMPv3 auth password.",
+               "value_type" : "string",
+               "multiple" : 0
+            },
+            {
+               "multiple" : 0,
+               "name" : "SNMPv3 auth protocol",
+               "default" : null,
+               "description" : "The SNMPv3 auth protocol.",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "value_desc" : "authprotocol",
+               "option" : "authprotocol"
+            },
+            {
+               "multiple" : 0,
+               "value_type" : "string",
+               "name" : "SNMPv3 priv key",
+               "description" : "The SNMPv3 priv key.",
+               "default" : null,
+               "value_desc" : "privkey",
+               "mandatory" : 0,
+               "option" : "privkey"
+            },
+            {
+               "multiple" : 0,
+               "value_type" : "string",
+               "default" : null,
+               "name" : "SNMPv3 priv password",
+               "description" : "The SNMPv3 priv password.",
+               "mandatory" : 0,
+               "value_desc" : "privpassword",
+               "option" : "privpassword"
+            },
+            {
+               "name" : "SNMPv3 priv protocol",
+               "description" : "The SNMPv3 priv protocol.",
+               "default" : null,
+               "value_type" : "string",
+               "multiple" : 0,
+               "option" : "privprotocol",
+               "mandatory" : 0,
+               "value_desc" : "privprotocol"
+            },
+            {
+               "option" : "warning",
+               "value_desc" : "key:value or key:op:value",
+               "mandatory" : 0,
+               "default" : null,
+               "name" : "Warning threshold",
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "value_type" : "string",
+               "multiple" : 1
+            },
+            {
+               "option" : "critical",
+               "mandatory" : 0,
+               "value_desc" : "key:value or key:op:value",
+               "value_type" : "string",
+               "default" : null,
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "name" : "Critical threshold",
+               "multiple" : 1
+            }
+         ],
+         "thresholds" : {
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "bytes",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for bytes:\n\n",
+               "    KB = Kilobytes   TB = Terabytes   ZB = Zettabytes\n",
+               "    MB = Megabytes   PB = Petabytes   YB = Yottabytes\n",
+               "    GB = Gigabytes   EB = Exabytes\n\n"
+            ],
+            "options" : [
+               {
+                  "key" : "DropEvents",
+                  "unit" : "none"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "Octets"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "Pkts"
+               },
+               {
+                  "key" : "BroadcastPkts",
+                  "unit" : "none"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "MulticastPkts"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "CRCAlignErrors"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "UndersizePkts"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "OversizePkts"
+               },
+               {
+                  "key" : "Fragments",
+                  "unit" : "none"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "Jabbers"
+               },
+               {
+                  "key" : "Collisions",
+                  "unit" : "none"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "Pkts64Octets"
+               },
+               {
+                  "key" : "Pkts65to127Octets",
+                  "unit" : "none"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "Pkts128to255Octets"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "Pkts256to511Octets"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "Pkts512to1023Octets"
+               },
+               {
+                  "unit" : "none",
+                  "key" : "Pkts1024to1518Octets"
+               }
+            ]
+         }
+      },
+      "prefer" : "localhost",
+      "datatype" : "statistic"
+   },
+   "chart" : [
+      {
+         "title" : "SNMP RMON Interface Bytes\"",
+         "id" : "1",
+         "options" : {
+            "series" : {
+               "color" : "#005467",
+               "name" : "Octets"
+            },
+            "units" : "bytes",
+            "chart-type" : "area",
+            "ylabel" : "bytes/s"
+         }
+      },
+      {
+         "options" : {
+            "series" : [
+               {
+                  "name" : "Pkts",
+                  "color" : "#005467"
+               },
+               {
+                  "color" : "#ffb244",
+                  "name" : "BroadcastPkts"
+               },
+               {
+                  "color" : "#2ba743",
+                  "name" : "MulticastPkts"
+               }
+            ],
+            "units" : "default",
+            "chart-type" : "line",
+            "ylabel" : "packets/s"
+         },
+         "id" : "2",
+         "title" : "SNMP RMON Interface Pakets\""
+      },
+      {
+         "id" : "3",
+         "title" : "SNMP RMON Interface Pakets Errors\"",
+         "options" : {
+            "series" : [
+               {
+                  "name" : "CRCAlignErrors",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "UndersizePkts",
+                  "color" : "#ffb244"
+               },
+               {
+                  "name" : "OversizePkts",
+                  "color" : "#2ba743"
+               },
+               {
+                  "name" : "Fragments",
+                  "color" : "#ff7a0d"
+               },
+               {
+                  "color" : "#e9644a",
+                  "name" : "Jabbers"
+               },
+               {
+                  "color" : "#9a72ad",
+                  "name" : "Collisions"
+               }
+            ],
+            "chart-type" : "line",
+            "ylabel" : "packets/s",
+            "units" : "default"
+         }
+      },
+      {
+         "id" : "4",
+         "title" : "SNMP RMON Interface Pakets sizes\"",
+         "options" : {
+            "chart-type" : "line",
+            "units" : "default",
+            "ylabel" : "packets/s",
+            "series" : [
+               {
+                  "color" : "#005467",
+                  "name" : "Pkts64Octets"
+               },
+               {
+                  "color" : "#ffb244",
+                  "name" : "Pkts65to127Octets"
+               },
+               {
+                  "name" : "Pkts128to255Octets",
+                  "color" : "#2ba743"
+               },
+               {
+                  "color" : "#ff7a0d",
+                  "name" : "Pkts256to511Octets"
+               },
+               {
+                  "name" : "Pkts512to1023Octets",
+                  "color" : "#e9644a"
+               },
+               {
+                  "name" : "Pkts1024to1518Octets",
+                  "color" : "#9a72ad"
+               }
+            ]
+         }
+      }
+   ],
+   "statistic" : [
+      {
+         "statkey" : "DropEvents",
+         "description" : "The total number of events in which packets were dropped by the probe due to lack of resources",
+         "alias" : "DropEvents",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "units" : "bytes",
+         "description" : "The total number of octets of data",
+         "statkey" : "Octets",
+         "alias" : "Octets",
+         "datatype" : "float"
+      },
+      {
+         "units" : "default",
+         "statkey" : "Pkts",
+         "description" : "The total number of packets received",
+         "datatype" : "float",
+         "alias" : "Pkts"
+      },
+      {
+         "statkey" : "BroadcastPkts",
+         "description" : "The total number of good packets received that were directed to the broadcast address",
+         "alias" : "BroadcastPkts",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "units" : "default",
+         "alias" : "MulticastPkts",
+         "datatype" : "float",
+         "statkey" : "MulticastPkts",
+         "description" : "The total number of good packets received that were directed to a multicast address"
+      },
+      {
+         "alias" : "CRCAlignErrors",
+         "datatype" : "float",
+         "description" : "The total number of packets received that had a bad FCS",
+         "statkey" : "CRCAlignErrors",
+         "units" : "default"
+      },
+      {
+         "alias" : "UndersizePkts",
+         "datatype" : "float",
+         "statkey" : "UndersizePkts",
+         "description" : "The total number of packets received that were less than 64 octets long",
+         "units" : "default"
+      },
+      {
+         "datatype" : "float",
+         "alias" : "OversizePkts",
+         "description" : "The total number of packets received that were longer than 1518 octets",
+         "statkey" : "OversizePkts",
+         "units" : "default"
+      },
+      {
+         "units" : "default",
+         "datatype" : "float",
+         "alias" : "Fragments",
+         "description" : "The total number of packets received that were less than 64 octets in length",
+         "statkey" : "Fragments"
+      },
+      {
+         "units" : "default",
+         "alias" : "Jabbers",
+         "datatype" : "float",
+         "description" : "The total number of packets received that were longer than 1518 octets",
+         "statkey" : "Jabbers"
+      },
+      {
+         "units" : "default",
+         "statkey" : "Collisions",
+         "description" : "The best estimate of the total number of collisions on this Ethernet segment",
+         "alias" : "Collisions",
+         "datatype" : "float"
+      },
+      {
+         "units" : "default",
+         "description" : "The total number of packets received that were 64 octets in length",
+         "statkey" : "Pkts64Octets",
+         "alias" : "Pkts64Octets",
+         "datatype" : "float"
+      },
+      {
+         "description" : "The total number of packets received that were between 65 and 127 octets in length",
+         "statkey" : "Pkts65to127Octets",
+         "alias" : "Pkts65to127Octets",
+         "datatype" : "float",
+         "units" : "default"
+      },
+      {
+         "units" : "default",
+         "alias" : "Pkts128to255Octets",
+         "datatype" : "float",
+         "description" : "The total number of packets received that were between 128 and 255 octets in length",
+         "statkey" : "Pkts128to255Octets"
+      },
+      {
+         "alias" : "Pkts256to511Octets",
+         "datatype" : "float",
+         "statkey" : "Pkts256to511Octets",
+         "description" : "The total number of packets received that were between 256 and 511 octets in length",
+         "units" : "default"
+      },
+      {
+         "units" : "default",
+         "description" : "The total number of packets received that were between 512 and 1023 octets in length",
+         "statkey" : "Pkts512to1023Octets",
+         "alias" : "Pkts512to1023Octets",
+         "datatype" : "float"
+      },
+      {
+         "units" : "default",
+         "description" : "The total number of packets received that were between 1024 and 1518 octets in length",
+         "statkey" : "Pkts1024to1518Octets",
+         "alias" : "Pkts1024to1518Octets",
+         "datatype" : "float"
+      }
+   ]
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-syno-disk
+++ b/plugins/snmp/Configs/Import/plugin-snmp-syno-disk
@@ -1,0 +1,362 @@
+{
+   "plugin" : {
+      "plugin" : "SNMP.Syno.Disk",
+      "category" : "Network,SNMP",
+      "netaccess" : "yes",
+      "info" : {
+         "version" : "0.3",
+         "examples" : [
+            {
+               "description" : [
+                  "Monitor the disk of a Synology NAS:"
+               ],
+               "command_line" : "check-snmp-syno-disk --disk 'sda' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "arguments" : [
+                  "disk",
+                  "sda",
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ]
+            }
+         ],
+         "options" : [
+            {
+               "value_type" : "string",
+               "mandatory" : 1,
+               "default" : null,
+               "value_desc" : "disk",
+               "multiple" : 0,
+               "description" : "This is the disk you want to check. For example sda",
+               "option" : "disk",
+               "name" : "Storage disk"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "value_desc" : "hostname or ip address",
+               "default" : "127.0.0.1",
+               "multiple" : 0,
+               "description" : "A hostname or IP address to connect to.",
+               "option" : "host",
+               "name" : "Hostname or IP address"
+            },
+            {
+               "default" : 161,
+               "value_desc" : "port",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "int",
+               "option" : "port",
+               "name" : "Port number",
+               "description" : "A port number to connect to."
+            },
+            {
+               "value_desc" : "community",
+               "default" : "public",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "community",
+               "name" : "SNMP community",
+               "description" : "The SNMP community to connect to the host."
+            },
+            {
+               "description" : "The SNMP version to use to connect to the host.",
+               "name" : "SNMP version",
+               "option" : "snmp-version",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "multiple" : 0,
+               "default" : 2,
+               "value_desc" : "version"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "default" : null,
+               "value_desc" : "username",
+               "multiple" : 0,
+               "description" : "The SNMPv3 username.",
+               "option" : "username",
+               "name" : "SNMPv3 username"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authkey",
+               "description" : "The SNMPv3 auth key.",
+               "name" : "SNMPv3 auth key",
+               "option" : "authkey"
+            },
+            {
+               "name" : "SNMPv3 auth password",
+               "option" : "authpassword",
+               "description" : "The SNMPv3 auth password.",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authpassword",
+               "mandatory" : 0,
+               "value_type" : "string"
+            },
+            {
+               "description" : "The SNMPv3 auth protocol.",
+               "name" : "SNMPv3 auth protocol",
+               "option" : "authprotocol",
+               "mandatory" : 0,
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authprotocol"
+            },
+            {
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "privkey",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "name" : "SNMPv3 priv key",
+               "option" : "privkey",
+               "description" : "The SNMPv3 priv key."
+            },
+            {
+               "default" : null,
+               "value_desc" : "privpassword",
+               "multiple" : 0,
+               "value_type" : "string",
+               "mandatory" : 0,
+               "option" : "privpassword",
+               "name" : "SNMPv3 priv password",
+               "description" : "The SNMPv3 priv password."
+            },
+            {
+               "default" : null,
+               "value_desc" : "privprotocol",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "privprotocol",
+               "name" : "SNMPv3 priv protocol",
+               "description" : "The SNMPv3 priv protocol."
+            },
+            {
+               "option" : "warning",
+               "name" : "Warning threshold",
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "default" : null,
+               "value_desc" : "key:value or key:op:value",
+               "multiple" : 1,
+               "value_type" : "string",
+               "mandatory" : 0
+            },
+            {
+               "name" : "Critical threshold",
+               "option" : "critical",
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "multiple" : 1,
+               "default" : null,
+               "value_desc" : "key:value or key:op:value",
+               "mandatory" : 0,
+               "value_type" : "string"
+            }
+         ],
+         "flags" : "",
+         "plugin" : "check-snmp-syno-disk",
+         "thresholds" : {
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "bytes",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for bytes:\n\n",
+               "    KB = Kilobytes   TB = Terabytes   ZB = Zettabytes\n",
+               "    MB = Megabytes   PB = Petabytes   YB = Yottabytes\n",
+               "    GB = Gigabytes   EB = Exabytes\n\n"
+            ],
+            "options" : [
+               {
+                  "unit" : "bytes",
+                  "key" : "bytes_read"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "bytes_write"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "iops_read"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "iops_write"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "avg_read_io_size"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "avg_write_io_size"
+               },
+               {
+                  "key" : "avg_load",
+                  "unit" : "percent"
+               }
+            ]
+         }
+      },
+      "description" : "Check the disk of a Synology NAS.",
+      "datatype" : "statistic",
+      "id" : "10002",
+      "abstract" : "Check snmp-syno-disk",
+      "prefer" : "localhost",
+      "command" : "check-snmp-syno-disk"
+   },
+   "statistic" : [
+      {
+         "units" : "bytes",
+         "datatype" : "float",
+         "description" : "The number of bytes read from this device",
+         "statkey" : "bytes_read",
+         "alias" : "Bytes read"
+      },
+      {
+         "statkey" : "bytes_write",
+         "alias" : "Bytes write",
+         "description" : "The number of bytes written to this device",
+         "datatype" : "float",
+         "units" : "bytes"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "The number of read accesses from this device",
+         "statkey" : "iops_read",
+         "alias" : "IOPS read"
+      },
+      {
+         "alias" : "IOPS write",
+         "statkey" : "iops_write",
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "The number of write accesses to this device"
+      },
+      {
+         "datatype" : "float",
+         "units" : "bytes",
+         "description" : "The average size of read IO",
+         "statkey" : "avg_read_io_size",
+         "alias" : "Size per read IO"
+      },
+      {
+         "alias" : "Size per write IO",
+         "statkey" : "avg_write_io_size",
+         "datatype" : "float",
+         "units" : "bytes",
+         "description" : "The average size of write IO"
+      },
+      {
+         "alias" : "Utilization %",
+         "statkey" : "avg_load",
+         "datatype" : "bigint",
+         "units" : "percent",
+         "description" : "Disk utilization"
+      }
+   ],
+   "chart" : [
+      {
+         "options" : {
+            "chart-type" : "area",
+            "series" : [
+               {
+                  "name" : "bytes_read",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "bytes_write",
+                  "opposite" : "true",
+                  "color" : "#ff7a0d"
+               }
+            ],
+            "ylabel" : "bytes read(+) / write(-)",
+            "units" : "bytes"
+         },
+         "title" : "SNMP syno disk - read/write rate",
+         "id" : "1"
+      },
+      {
+         "title" : "SNMP syno disk - read/write IOPS",
+         "id" : "2",
+         "options" : {
+            "ylabel" : "iops read(+) / write(-)",
+            "units" : "defaut",
+            "series" : [
+               {
+                  "name" : "iops_read",
+                  "color" : "#005467"
+               },
+               {
+                  "color" : "#ff7a0d",
+                  "opposite" : "true",
+                  "name" : "iops_write"
+               }
+            ],
+            "chart-type" : "area"
+         }
+      },
+      {
+         "options" : {
+            "series" : {
+                  "color" : "#005467",
+                  "name" : "avg_load"
+               },
+            "chart-type" : "area",
+            "ylabel" : "percent",
+            "units" : "null"
+         },
+         "id" : "3",
+         "title" : "SNMP syno disk - Load"
+      },
+      {
+         "title" : "SNMP syno disk - average read/write IOPS size",
+         "id" : "4",
+         "options" : {
+            "ylabel" : "iops size read(+) / size write(-)",
+            "units" : "bytes",
+            "series" : [
+               {
+                  "name" : "avg_read_io_size",
+                  "color" : "#005467"
+               },
+               {
+                  "color" : "#ff7a0d",
+                  "opposite" : "true",
+                  "name" : "avg_write_io_size"
+               }
+            ],
+            "chart-type" : "area"
+         }
+      }
+   ]
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-syno-lv
+++ b/plugins/snmp/Configs/Import/plugin-snmp-syno-lv
@@ -1,0 +1,362 @@
+{
+   "plugin" : {
+      "plugin" : "SNMP.Syno.Lv",
+      "category" : "Network,SNMP",
+      "netaccess" : "yes",
+      "info" : {
+         "version" : "0.3",
+         "examples" : [
+            {
+               "description" : [
+                  "Monitor the logical volume of a Synology NAS:"
+               ],
+               "command_line" : "check-snmp-syno-lv --lv 'dm-1' --host '127.0.0.1' --port '161' --community 'public' --snmp-version '1'",
+               "arguments" : [
+                  "lv",
+                  "dm-1",
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "snmp-version",
+                  1
+               ]
+            }
+         ],
+         "options" : [
+            {
+               "value_type" : "string",
+               "mandatory" : 1,
+               "default" : null,
+               "value_desc" : "lv",
+               "multiple" : 0,
+               "description" : "This is the lv you want to check. Volume 1 is usal dm-1. Check with 'dmsetup info /dev/dm-x'",
+               "option" : "lv",
+               "name" : "Storage lv"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "value_desc" : "hostname or ip address",
+               "default" : "127.0.0.1",
+               "multiple" : 0,
+               "description" : "A hostname or IP address to connect to.",
+               "option" : "host",
+               "name" : "Hostname or IP address"
+            },
+            {
+               "default" : 161,
+               "value_desc" : "port",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "int",
+               "option" : "port",
+               "name" : "Port number",
+               "description" : "A port number to connect to."
+            },
+            {
+               "value_desc" : "community",
+               "default" : "public",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "community",
+               "name" : "SNMP community",
+               "description" : "The SNMP community to connect to the host."
+            },
+            {
+               "description" : "The SNMP version to use to connect to the host.",
+               "name" : "SNMP version",
+               "option" : "snmp-version",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "multiple" : 0,
+               "default" : 2,
+               "value_desc" : "version"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "default" : null,
+               "value_desc" : "username",
+               "multiple" : 0,
+               "description" : "The SNMPv3 username.",
+               "option" : "username",
+               "name" : "SNMPv3 username"
+            },
+            {
+               "mandatory" : 0,
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authkey",
+               "description" : "The SNMPv3 auth key.",
+               "name" : "SNMPv3 auth key",
+               "option" : "authkey"
+            },
+            {
+               "name" : "SNMPv3 auth password",
+               "option" : "authpassword",
+               "description" : "The SNMPv3 auth password.",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authpassword",
+               "mandatory" : 0,
+               "value_type" : "string"
+            },
+            {
+               "description" : "The SNMPv3 auth protocol.",
+               "name" : "SNMPv3 auth protocol",
+               "option" : "authprotocol",
+               "mandatory" : 0,
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "authprotocol"
+            },
+            {
+               "multiple" : 0,
+               "default" : null,
+               "value_desc" : "privkey",
+               "value_type" : "string",
+               "mandatory" : 0,
+               "name" : "SNMPv3 priv key",
+               "option" : "privkey",
+               "description" : "The SNMPv3 priv key."
+            },
+            {
+               "default" : null,
+               "value_desc" : "privpassword",
+               "multiple" : 0,
+               "value_type" : "string",
+               "mandatory" : 0,
+               "option" : "privpassword",
+               "name" : "SNMPv3 priv password",
+               "description" : "The SNMPv3 priv password."
+            },
+            {
+               "default" : null,
+               "value_desc" : "privprotocol",
+               "multiple" : 0,
+               "mandatory" : 0,
+               "value_type" : "string",
+               "option" : "privprotocol",
+               "name" : "SNMPv3 priv protocol",
+               "description" : "The SNMPv3 priv protocol."
+            },
+            {
+               "option" : "warning",
+               "name" : "Warning threshold",
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "default" : null,
+               "value_desc" : "key:value or key:op:value",
+               "multiple" : 1,
+               "value_type" : "string",
+               "mandatory" : 0
+            },
+            {
+               "name" : "Critical threshold",
+               "option" : "critical",
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "multiple" : 1,
+               "default" : null,
+               "value_desc" : "key:value or key:op:value",
+               "mandatory" : 0,
+               "value_type" : "string"
+            }
+         ],
+         "flags" : "",
+         "plugin" : "check-snmp-syno-lv",
+         "thresholds" : {
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  or if a unit makes sense\n\n",
+               "    key:operator:threshold + UNIT\n\n",
+               "  where the unit can be in ",
+               "bytes",
+               ".\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n",
+               "\n",
+               "  Allowed units for bytes:\n\n",
+               "    KB = Kilobytes   TB = Terabytes   ZB = Zettabytes\n",
+               "    MB = Megabytes   PB = Petabytes   YB = Yottabytes\n",
+               "    GB = Gigabytes   EB = Exabytes\n\n"
+            ],
+            "options" : [
+               {
+                  "unit" : "bytes",
+                  "key" : "bytes_read"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "bytes_write"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "iops_read"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "iops_write"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "avg_read_io_size"
+               },
+               {
+                  "unit" : "bytes",
+                  "key" : "avg_write_io_size"
+               },
+               {
+                  "key" : "avg_load",
+                  "unit" : "percent"
+               }
+            ]
+         }
+      },
+      "description" : "Check the logical volume of a Synology NAS.",
+      "datatype" : "statistic",
+      "id" : "10003",
+      "abstract" : "Check snmp-syno-lv",
+      "prefer" : "localhost",
+      "command" : "check-snmp-syno-lv"
+   },
+   "statistic" : [
+      {
+         "units" : "bytes",
+         "datatype" : "float",
+         "description" : "The number of bytes read from this device",
+         "statkey" : "bytes_read",
+         "alias" : "Bytes read"
+      },
+      {
+         "statkey" : "bytes_write",
+         "alias" : "Bytes write",
+         "description" : "The number of bytes written to this device",
+         "datatype" : "float",
+         "units" : "bytes"
+      },
+      {
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "The number of read accesses from this device",
+         "statkey" : "iops_read",
+         "alias" : "IOPS read"
+      },
+      {
+         "alias" : "IOPS write",
+         "statkey" : "iops_write",
+         "datatype" : "float",
+         "units" : "default",
+         "description" : "The number of write accesses to this device"
+      },
+      {
+         "datatype" : "float",
+         "units" : "bytes",
+         "description" : "The average size of Read IO",
+         "statkey" : "avg_read_io_size",
+         "alias" : "Size per read IO"
+      },
+      {
+         "alias" : "Size per write IO",
+         "statkey" : "avg_write_io_size",
+         "datatype" : "float",
+         "units" : "bytes",
+         "description" : "The average size of Write IO"
+      },
+      {
+         "alias" : "Utilization %",
+         "statkey" : "avg_load",
+         "datatype" : "bigint",
+         "units" : "percent",
+         "description" : "Utilization of the volume"
+      }
+   ],
+   "chart" : [
+      {
+         "options" : {
+            "chart-type" : "area",
+            "series" : [
+               {
+                  "name" : "bytes_read",
+                  "color" : "#005467"
+               },
+               {
+                  "name" : "bytes_write",
+                  "opposite" : "true",
+                  "color" : "#ff7a0d"
+               }
+            ],
+            "ylabel" : "bytes read(+) / write(-)",
+            "units" : "bytes"
+         },
+         "title" : "SNMP syno lv - read/write rate",
+         "id" : "1"
+      },
+      {
+         "title" : "SNMP syno lv - read/write IOPS",
+         "id" : "2",
+         "options" : {
+            "ylabel" : "iops read(+) / write(-)",
+            "units" : "defaut",
+            "series" : [
+               {
+                  "name" : "iops_read",
+                  "color" : "#005467"
+               },
+               {
+                  "color" : "#ff7a0d",
+                  "opposite" : "true",
+                  "name" : "iops_write"
+               }
+            ],
+            "chart-type" : "area"
+         }
+      },
+      {
+         "options" : {
+            "series" : {
+                  "color" : "#005467",
+                  "name" : "avg_load"
+               },
+            "chart-type" : "area",
+            "ylabel" : "percent",
+            "units" : "null"
+         },
+         "id" : "3",
+         "title" : "SNMP syno lv - volume load"
+      },
+      {
+         "title" : "SNMP syno lv - average read/write IOPS size",
+         "id" : "4",
+         "options" : {
+            "ylabel" : "iops size read(+) / size write(-)",
+            "units" : "bytes",
+            "series" : [
+               {
+                  "name" : "avg_read_io_size",
+                  "color" : "#005467"
+               },
+               {
+                  "color" : "#ff7a0d",
+                  "opposite" : "true",
+                  "name" : "avg_write_io_size"
+               }
+            ],
+            "chart-type" : "area"
+         }
+      }
+   ]
+}

--- a/plugins/snmp/Configs/Import/plugin-snmp-temperature
+++ b/plugins/snmp/Configs/Import/plugin-snmp-temperature
@@ -1,0 +1,220 @@
+{
+   "plugin" : {
+      "description" : "Check the Temperature of a Device by OID.",
+      "id" : "10001",
+      "info" : {
+         "options" : [
+            {
+               "mandatory" : 0,
+               "name" : "Hostname or IP address",
+               "description" : "A hostname or IP address to connect to.",
+               "default" : "127.0.0.1",
+               "multiple" : 0,
+               "value_type" : "string",
+               "option" : "host",
+               "value_desc" : "hostname or ip address"
+            },
+            {
+               "mandatory" : 0,
+               "name" : "Port number",
+               "description" : "A port number to connect to.",
+               "default" : 161,
+               "multiple" : 0,
+               "value_type" : "int",
+               "option" : "port",
+               "value_desc" : "port"
+            },
+            {
+               "mandatory" : 0,
+               "name" : "SNMP community",
+               "description" : "The SNMP community to connect to the host.",
+               "default" : "public",
+               "option" : "community",
+               "value_type" : "string",
+               "multiple" : 0,
+               "value_desc" : "community"
+            },
+            {
+               "mandatory" : 0,
+               "name" : "SNMP version",
+               "description" : "The SNMP version to use to connect to the host.",
+               "default" : 2,
+               "multiple" : 0,
+               "option" : "snmp-version",
+               "value_type" : "string",
+               "value_desc" : "version"
+            },
+            {
+               "value_desc" : "username",
+               "multiple" : 0,
+               "option" : "username",
+               "value_type" : "string",
+               "default" : null,
+               "description" : "The SNMPv3 username.",
+               "name" : "SNMPv3 username",
+               "mandatory" : 0
+            },
+            {
+               "description" : "The SNMPv3 auth key.",
+               "default" : null,
+               "name" : "SNMPv3 auth key",
+               "mandatory" : 0,
+               "value_desc" : "authkey",
+               "option" : "authkey",
+               "value_type" : "string",
+               "multiple" : 0
+            },
+            {
+               "description" : "The SNMPv3 auth password.",
+               "default" : null,
+               "name" : "SNMPv3 auth password",
+               "mandatory" : 0,
+               "value_desc" : "authpassword",
+               "multiple" : 0,
+               "option" : "authpassword",
+               "value_type" : "string"
+            },
+            {
+               "mandatory" : 0,
+               "name" : "SNMPv3 auth protocol",
+               "description" : "The SNMPv3 auth protocol.",
+               "default" : null,
+               "multiple" : 0,
+               "value_type" : "string",
+               "option" : "authprotocol",
+               "value_desc" : "authprotocol"
+            },
+            {
+               "mandatory" : 0,
+               "description" : "The SNMPv3 priv key.",
+               "default" : null,
+               "name" : "SNMPv3 priv key",
+               "value_type" : "string",
+               "option" : "privkey",
+               "multiple" : 0,
+               "value_desc" : "privkey"
+            },
+            {
+               "mandatory" : 0,
+               "name" : "SNMPv3 priv password",
+               "description" : "The SNMPv3 priv password.",
+               "default" : null,
+               "value_type" : "string",
+               "option" : "privpassword",
+               "multiple" : 0,
+               "value_desc" : "privpassword"
+            },
+            {
+               "value_desc" : "privprotocol",
+               "option" : "privprotocol",
+               "value_type" : "string",
+               "multiple" : 0,
+               "default" : null,
+               "description" : "The SNMPv3 priv protocol.",
+               "name" : "SNMPv3 priv protocol",
+               "mandatory" : 0
+            },
+            {
+               "description" : "The OID to check.",
+               "default" : "",
+               "name" : "The OID to check",
+               "mandatory" : 1,
+               "value_desc" : "string",
+               "option" : "oid",
+               "value_type" : "string",
+               "multiple" : 0
+            },
+            {
+               "default" : null,
+               "description" : "This is the warning threshold. When the value exceeds the threshold a warning status is triggered. Please see the examples for more information.",
+               "name" : "Warning threshold",
+               "mandatory" : 0,
+               "value_desc" : "key:value or key:op:value",
+               "option" : "warning",
+               "value_type" : "string",
+               "multiple" : 1
+            },
+            {
+               "default" : null,
+               "description" : "This is the critical threshold. When the value exceeds the threshold a critical status is triggered. Please see the examples for more information.",
+               "name" : "Critical threshold",
+               "mandatory" : 0,
+               "value_desc" : "key:value or key:op:value",
+               "option" : "critical",
+               "value_type" : "string",
+               "multiple" : 1
+            }
+         ],
+         "flags" : "",
+         "examples" : [
+            {
+               "description" : [
+                  "Example to check if a system is alive:"
+               ],
+               "command_line" : "check-snmp-temperature --host '127.0.0.1' --port '161' --community 'public' --oid '1.3.6.1.2.1.1.5.0'",
+               "arguments" : [
+                  "host",
+                  "127.0.0.1",
+                  "port",
+                  161,
+                  "community",
+                  "public",
+                  "oid",
+                  "1.3.6.1.2.1.1.5.0"
+               ]
+            }
+         ],
+         "version" : "0.1",
+         "thresholds" : {
+            "info" : [
+               "How to set warning and critical thresholds:\n\n",
+               "  It's possible to set thresholds for one or more statistic keys.\n",
+               "  The format to add a threshold for a statistic key is:\n\n",
+               "    key:operator:threshold\n\n",
+               "  If no operator is set then the default operator is 'ge'.\n\n",
+               "  The following operators are available:\n\n",
+               "    lt = less than\n",
+               "    le = less than or equal\n",
+               "    gt = greater than\n",
+               "    ge = greater than or equal\n",
+               "    eq = equal\n",
+               "    ne = not equal\n"
+            ],
+            "options" : [
+               {
+                  "key" : "temperature",
+                  "unit" : "none"
+               }
+            ]
+         },
+         "plugin" : "check-snmp-temperature"
+      },
+      "datatype" : "statistic",
+      "plugin" : "SNMP.Check.Temperature",
+      "command" : "check-snmp-temperature",
+      "netaccess" : "yes",
+      "abstract" : "SNMP Temperature check by OID",
+      "category" : "System,SNMP",
+      "prefer" : "localhost"
+   },
+   "chart" : {
+      "title" : "Temperature",
+      "id" : "1",
+      "options" : {
+         "chart-type" : "area",
+         "units" : "null",
+         "ylabel" : "celsius",
+         "series" : {
+            "name" : "temperature",
+            "color" : "#005467"
+         }
+      }
+   },
+   "statistic" : {
+      "description" : "The temperatur of the sensor.",
+      "datatype" : "float",
+      "statkey" : "temperature",
+      "alias" : "Temperature",
+      "units" : "temperature"
+   }
+}

--- a/plugins/snmp/Configs/plugin-snmp-cisco-fw
+++ b/plugins/snmp/Configs/plugin-snmp-cisco-fw
@@ -1,0 +1,1015 @@
+plugin {
+    id 10008
+    plugin SNMP.Cisco.Fw
+    command check-snmp-cisco-fw
+    datatype statistic
+    category System,SNMP
+    netaccess yes
+    prefer localhost
+    abstract Cisco Firewall check
+    description Monitor the firewall of a Cisco Router.
+}
+
+statistic {
+    statkey GCNumAttempted
+    alias GCNumAttempted
+    datatype float
+    units default
+    description Number of connections which are attempted to be set up.
+}
+
+statistic {
+    statkey GCNumSetupsAborted
+    alias GCNumSetupsAborted
+    datatype float
+    units default
+    description Number of connection setup attempts that were aborted.
+}
+
+statistic {
+    statkey GCNumPolicyDeclined
+    alias GCNumPolicyDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined due to security reasons.
+}
+
+statistic {
+    statkey GCNumResDeclined
+    alias GCNumResDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined du to non-availability of required resources.
+}
+
+statistic {
+    statkey GCNumHalfOpen
+    alias GCNumHalfOpen
+    datatype bigint
+    units default
+    description Connections which are in the process of being setup.
+}
+
+statistic {
+    statkey GCNumActive
+    alias GCNumActive
+    datatype bigint
+    units default
+    description Number of connections which are currently active.
+}
+
+statistic {
+    statkey GCNumExpired
+    alias GCNumExpired
+    datatype float
+    units default
+    description Connections which were active but which were since normally terminated.
+}
+
+statistic {
+    statkey GCNumAborted
+    alias GCNumAborted
+    datatype float
+    units default
+    description Connections which were active but which were aborted due to reasons of policy or resource rationing.
+}
+
+statistic {
+    statkey GCNumEmbryonic
+    alias GCNumEmbryonic
+    datatype bigint
+    units default
+    description Embryonic application layer connections.
+}
+
+statistic {
+    statkey GCSetupRate1
+    alias GCSetupRate1
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last minute.
+}
+
+statistic {
+    statkey GCSetupRate5
+    alias GCSetupRate5
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last 5 minute.
+}
+
+statistic {
+    statkey GCNumRemoteAccess
+    alias GCNumRemoteAccess
+    datatype bigint
+    units default
+    description Active connections which correspond to remote access applications(PPP, PPTP, L2TP, IPSEC).
+}
+
+statistic {
+    statkey ICMP_NumAttempted
+    alias ICMP_NumAttempted
+    datatype float
+    units default
+    description Number of connections which are attempted to be set up.
+}
+
+statistic {
+    statkey ICMP_NumSetupsAborted
+    alias ICMP_NumSetupsAborted
+    datatype float
+    units default
+    description Number of connection setup attempts that were aborted.
+}
+
+statistic {
+    statkey ICMP_NumPolicyDeclined
+    alias ICMP_NumPolicyDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined due to security reasons.
+}
+
+statistic {
+    statkey ICMP_NumResDeclined
+    alias ICMP_NumResDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined du to non-availability of required resources.
+}
+
+statistic {
+    statkey ICMP_NumHalfOpen
+    alias ICMP_NumHalfOpen
+    datatype bigint
+    units default
+    description Connections which are in the process of being setup.
+}
+
+statistic {
+    statkey ICMP_NumActive
+    alias ICMP_NumActive
+    datatype bigint
+    units default
+    description Number of connections which are currently active.
+}
+
+statistic {
+    statkey ICMP_NumExpired
+    alias ICMP_NumExpired
+    datatype float
+    units default
+    description Connections which were active but which were since normally terminated.
+}
+
+statistic {
+    statkey ICMP_NumAborted
+    alias ICMP_NumAborted
+    datatype float
+    units default
+    description Connections which were active but which were aborted due to reasons of policy or resource rationing.
+}
+
+statistic {
+    statkey ICMP_SetupRate1
+    alias ICMP_SetupRate1
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last minute.
+}
+
+statistic {
+    statkey ICMP_SetupRate5
+    alias ICMP_SetupRate5
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last 5 minute.
+}
+
+statistic {
+    statkey TCP_NumAttempted
+    alias TCP_NumAttempted
+    datatype float
+    units default
+    description Number of connections which are attempted to be set up.
+}
+
+statistic {
+    statkey TCP_NumSetupsAborted
+    alias TCP_NumSetupsAborted
+    datatype float
+    units default
+    description Number of connection setup attempts that were aborted.
+}
+
+statistic {
+    statkey TCP_NumPolicyDeclined
+    alias TCP_NumPolicyDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined due to security reasons.
+}
+
+statistic {
+    statkey TCP_NumResDeclined
+    alias TCP_NumResDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined du to non-availability of required resources.
+}
+
+statistic {
+    statkey TCP_NumHalfOpen
+    alias TCP_NumHalfOpen
+    datatype bigint
+    units default
+    description Connections which are in the process of being setup.
+}
+
+statistic {
+    statkey TCP_NumActive
+    alias TCP_NumActive
+    datatype bigint
+    units default
+    description Number of connections which are currently active.
+}
+
+statistic {
+    statkey TCP_NumExpired
+    alias TCP_NumExpired
+    datatype float
+    units default
+    description Connections which were active but which were since normally terminated.
+}
+
+statistic {
+    statkey TCP_NumAborted
+    alias TCP_NumAborted
+    datatype float
+    units default
+    description Connections which were active but which were aborted due to reasons of policy or resource rationing.
+}
+
+statistic {
+    statkey TCP_SetupRate1
+    alias TCP_SetupRate1
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last minute.
+}
+
+statistic {
+    statkey TCP_SetupRate5
+    alias TCP_SetupRate5
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last 5 minute.
+}
+
+statistic {
+    statkey UDP_NumAttempted
+    alias UDP_NumAttempted
+    datatype float
+    units default
+    description Number of connections which are attempted to be set up.
+}
+
+statistic {
+    statkey UDP_NumSetupsAborted
+    alias UDP_NumSetupsAborted
+    datatype float
+    units default
+    description Number of connection setup attempts that were aborted.
+}
+
+statistic {
+    statkey UDP_NumPolicyDeclined
+    alias UDP_NumPolicyDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined due to security reasons.
+}
+
+statistic {
+    statkey UDP_NumResDeclined
+    alias UDP_NumResDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined du to non-availability of required resources.
+}
+
+statistic {
+    statkey UDP_NumHalfOpen
+    alias UDP_NumHalfOpen
+    datatype bigint
+    units default
+    description Connections which are in the process of being setup.
+}
+
+statistic {
+    statkey UDP_NumActive
+    alias UDP_NumActive
+    datatype bigint
+    units default
+    description Number of connections which are currently active.
+}
+
+statistic {
+    statkey UDP_NumExpired
+    alias UDP_NumExpired
+    datatype float
+    units default
+    description Connections which were active but which were since normally terminated.
+}
+
+statistic {
+    statkey UDP_NumAborted
+    alias UDP_NumAborted
+    datatype float
+    units default
+    description Connections which were active but which were aborted due to reasons of policy or resource rationing.
+}
+
+statistic {
+    statkey UDP_SetupRate1
+    alias UDP_SetupRate1
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last minute.
+}
+
+statistic {
+    statkey UDP_SetupRate5
+    alias UDP_SetupRate5
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last 5 minute.
+}
+
+statistic {
+    statkey HTTP_NumAttempted
+    alias HTTP_NumAttempted
+    datatype float
+    units default
+    description Number of connections which are attempted to be set up.
+}
+
+statistic {
+    statkey HTTP_NumSetupsAborted
+    alias HTTP_NumSetupsAborted
+    datatype float
+    units default
+    description Number of connection setup attempts that were aborted.
+}
+
+statistic {
+    statkey HTTP_NumPolicyDeclined
+    alias HTTP_NumPolicyDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined due to security reasons.
+}
+
+statistic {
+    statkey HTTP_NumResDeclined
+    alias HTTP_NumResDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined du to non-availability of required resources.
+}
+
+statistic {
+    statkey HTTP_NumHalfOpen
+    alias HTTP_NumHalfOpen
+    datatype bigint
+    units default
+    description Connections which are in the process of being setup.
+}
+
+statistic {
+    statkey HTTP_NumActive
+    alias HTTP_NumActive
+    datatype bigint
+    units default
+    description Number of connections which are currently active.
+}
+
+statistic {
+    statkey HTTP_NumExpired
+    alias HTTP_NumExpired
+    datatype float
+    units default
+    description Connections which were active but which were since normally terminated.
+}
+
+statistic {
+    statkey HTTP_NumAborted
+    alias HTTP_NumAborted
+    datatype float
+    units default
+    description Connections which were active but which were aborted due to reasons of policy or resource rationing.
+}
+
+statistic {
+    statkey HTTP_SetupRate1
+    alias HTTP_SetupRate1
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last minute.
+}
+
+statistic {
+    statkey HTTP_SetupRate5
+    alias HTTP_SetupRate5
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last 5 minute.
+}
+
+statistic {
+    statkey HTTPS_NumAttempted
+    alias HTTPS_NumAttempted
+    datatype float
+    units default
+    description Number of connections which are attempted to be set up.
+}
+
+statistic {
+    statkey HTTPS_NumSetupsAborted
+    alias HTTPS_NumSetupsAborted
+    datatype float
+    units default
+    description Number of connection setup attempts that were aborted.
+}
+
+statistic {
+    statkey HTTPS_NumPolicyDeclined
+    alias HTTPS_NumPolicyDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined due to security reasons.
+}
+
+statistic {
+    statkey HTTPS_NumResDeclined
+    alias HTTPS_NumResDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined du to non-availability of required resources.
+}
+
+statistic {
+    statkey HTTPS_NumHalfOpen
+    alias HTTPS_NumHalfOpen
+    datatype bigint
+    units default
+    description Connections which are in the process of being setup.
+}
+
+statistic {
+    statkey HTTPS_NumActive
+    alias HTTPS_NumActive
+    datatype bigint
+    units default
+    description Number of connections which are currently active.
+}
+
+statistic {
+    statkey HTTPS_NumExpired
+    alias HTTPS_NumExpired
+    datatype float
+    units default
+    description Connections which were active but which were since normally terminated.
+}
+
+statistic {
+    statkey HTTPS_NumAborted
+    alias HTTPS_NumAborted
+    datatype float
+    units default
+    description Connections which were active but which were aborted due to reasons of policy or resource rationing.
+}
+
+statistic {
+    statkey HTTPS_SetupRate1
+    alias HTTPS_SetupRate1
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last minute.
+}
+
+statistic {
+    statkey HTTPS_SetupRate5
+    alias HTTPS_SetupRate5
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last 5 minute.
+}
+
+statistic {
+    statkey DNS_NumAttempted
+    alias DNS_NumAttempted
+    datatype float
+    units default
+    description Number of connections which are attempted to be set up.
+}
+
+statistic {
+    statkey DNS_NumSetupsAborted
+    alias DNS_NumSetupsAborted
+    datatype float
+    units default
+    description Number of connection setup attempts that were aborted.
+}
+
+statistic {
+    statkey DNS_NumPolicyDeclined
+    alias DNS_NumPolicyDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined due to security reasons.
+}
+
+statistic {
+    statkey DNS_NumResDeclined
+    alias DNS_NumResDeclined
+    datatype float
+    units default
+    description Number of connection setup attempts that were declined du to non-availability of required resources.
+}
+
+statistic {
+    statkey DNS_NumHalfOpen
+    alias DNS_NumHalfOpen
+    datatype bigint
+    units default
+    description Connections which are in the process of being setup.
+}
+
+statistic {
+    statkey DNS_NumActive
+    alias DNS_NumActive
+    datatype bigint
+    units default
+    description Number of connections which are currently active.
+}
+
+statistic {
+    statkey DNS_NumExpired
+    alias DNS_NumExpired
+    datatype float
+    units default
+    description Connections which were active but which were since normally terminated.
+}
+
+statistic {
+    statkey DNS_NumAborted
+    alias DNS_NumAborted
+    datatype float
+    units default
+    description Connections which were active but which were aborted due to reasons of policy or resource rationing.
+}
+
+statistic {
+    statkey DNS_SetupRate1
+    alias DNS_SetupRate1
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last minute.
+}
+
+statistic {
+    statkey DNS_SetupRate5
+    alias DNS_SetupRate5
+    datatype bigint
+    units default
+    description Averaged number of connections establishing per second over the last 5 minute.
+}
+
+chart {
+    id 1
+    title Global Connection Events
+    options {
+        ylabel Events/s
+        units default
+        chart-type line
+        series {
+            name GCNumAttempted
+            color \#339900
+        }
+        series {
+            name GCNumSetupsAborted
+            color \#666666
+        }
+        series {
+            name GCNumPolicyDeclined
+            color \#FF0000
+        }
+        series {
+            name GCNumResDeclined
+            color \#990000
+        }
+        series {
+            name GCNumExpired
+            color \#cc3399
+        }
+        series {
+            name GCNumAborted
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 2
+    title Global Connection Statistics
+    options {
+        ylabel Connections
+        units default
+        chart-type line
+        series {
+            name GCNumActive
+            color \#339900
+        }
+        series {
+            name GCNumHalfOpen
+            color \#666666
+        }
+        series {
+            name GCNumEmbryonic
+            color \#FF0000
+        }
+        series {
+            name GCNumRemoteAccess
+            color \#990000
+        }
+        series {
+            name GCSetupRate1
+            color \#cc3399
+        }
+        series {
+            name GCSetupRate5
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 3
+    title ICMP Connection Events
+    options {
+        ylabel Events/s
+        units default
+        chart-type line
+        series {
+            name ICMPNumAttempted
+            color \#339900
+        }
+        series {
+            name ICMPNumSetupsAborted
+            color \#666666
+        }
+        series {
+            name ICMPNumPolicyDeclined
+            color \#FF0000
+        }
+        series {
+            name ICMPNumResDeclined
+            color \#990000
+        }
+        series {
+            name ICMPNumExpired
+            color \#cc3399
+        }
+        series {
+            name ICMPNumAborted
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 4
+    title ICMP Connection Statistics
+    options {
+        ylabel Connections
+        units default
+        chart-type line
+        series {
+            name ICMPNumActive
+            color \#339900
+        }
+        series {
+            name ICMPNumHalfOpen
+            color \#666666
+        }
+        series {
+            name ICMPSetupRate1
+            color \#cc3399
+        }
+        series {
+            name ICMPSetupRate5
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 5
+    title TCP Connection Events
+    options {
+        ylabel Events/s
+        units default
+        chart-type line
+        series {
+            name TCPNumAttempted
+            color \#339900
+        }
+        series {
+            name TCPNumSetupsAborted
+            color \#666666
+        }
+        series {
+            name TCPNumPolicyDeclined
+            color \#FF0000
+        }
+        series {
+            name TCPNumResDeclined
+            color \#990000
+        }
+        series {
+            name TCPNumExpired
+            color \#cc3399
+        }
+        series {
+            name TCPNumAborted
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 6
+    title TCP Connection Statistics
+    options {
+        ylabel Connections
+        units default
+        chart-type line
+        series {
+            name TCPNumActive
+            color \#339900
+        }
+        series {
+            name TCPNumHalfOpen
+            color \#666666
+        }
+        series {
+            name TCPSetupRate1
+            color \#cc3399
+        }
+        series {
+            name TCPSetupRate5
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 7
+    title UDP Connection Events
+    options {
+        ylabel Events/s
+        units default
+        chart-type line
+        series {
+            name UDPNumAttempted
+            color \#339900
+        }
+        series {
+            name UDPNumSetupsAborted
+            color \#666666
+        }
+        series {
+            name UDPNumPolicyDeclined
+            color \#FF0000
+        }
+        series {
+            name UDPNumResDeclined
+            color \#990000
+        }
+        series {
+            name UDPNumExpired
+            color \#cc3399
+        }
+        series {
+            name UDPNumAborted
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 8
+    title UDP Connection Statistics
+    options {
+        ylabel Connections
+        units default
+        chart-type line
+        series {
+            name UDPNumActive
+            color \#339900
+        }
+        series {
+            name UDPNumHalfOpen
+            color \#666666
+        }
+        series {
+            name UDPSetupRate1
+            color \#cc3399
+        }
+        series {
+            name UDPSetupRate5
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 9
+    title HTTP Connection Events
+    options {
+        ylabel Events/s
+        units default
+        chart-type line
+        series {
+            name HTTPNumAttempted
+            color \#339900
+        }
+        series {
+            name HTTPNumSetupsAborted
+            color \#666666
+        }
+        series {
+            name HTTPNumPolicyDeclined
+            color \#FF0000
+        }
+        series {
+            name HTTPNumResDeclined
+            color \#990000
+        }
+        series {
+            name HTTPNumExpired
+            color \#cc3399
+        }
+        series {
+            name HTTPNumAborted
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 10
+    title HTTP Connection Statistics
+    options {
+        ylabel Connections
+        units default
+        chart-type line
+        series {
+            name HTTPNumActive
+            color \#339900
+        }
+        series {
+            name HTTPNumHalfOpen
+            color \#666666
+        }
+        series {
+            name HTTPSetupRate1
+            color \#cc3399
+        }
+        series {
+            name HTTPSetupRate5
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 11
+    title HTTPS Connection Events
+    options {
+        ylabel Events/s
+        units default
+        chart-type line
+        series {
+            name HTTPSNumAttempted
+            color \#339900
+        }
+        series {
+            name HTTPSNumSetupsAborted
+            color \#666666
+        }
+        series {
+            name HTTPSNumPolicyDeclined
+            color \#FF0000
+        }
+        series {
+            name HTTPSNumResDeclined
+            color \#990000
+        }
+        series {
+            name HTTPSNumExpired
+            color \#cc3399
+        }
+        series {
+            name HTTPSNumAborted
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 12
+    title HTTPS Connection Statistics
+    options {
+        ylabel Connections
+        units default
+        chart-type line
+        series {
+            name HTTPSNumActive
+            color \#339900
+        }
+        series {
+            name HTTPSNumHalfOpen
+            color \#666666
+        }
+        series {
+            name HTTPSSetupRate1
+            color \#cc3399
+        }
+        series {
+            name HTTPSSetupRate5
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 13
+    title DNS Connection Events
+    options {
+        ylabel Events/s
+        units default
+        chart-type line
+        series {
+            name DNSNumAttempted
+            color \#339900
+        }
+        series {
+            name DNSNumSetupsAborted
+            color \#666666
+        }
+        series {
+            name DNSNumPolicyDeclined
+            color \#FF0000
+        }
+        series {
+            name DNSNumResDeclined
+            color \#990000
+        }
+        series {
+            name DNSNumExpired
+            color \#cc3399
+        }
+        series {
+            name DNSNumAborted
+            color \#9933cc
+        }
+    }
+}
+
+chart {
+    id 14
+    title DNS Connection Statistics
+    options {
+        ylabel Connections
+        units default
+        chart-type line
+        series {
+            name DNSNumActive
+            color \#339900
+        }
+        series {
+            name DNSNumHalfOpen
+            color \#666666
+        }
+        series {
+            name DNSSetupRate1
+            color \#cc3399
+        }
+        series {
+            name DNSSetupRate5
+            color \#9933cc
+        }
+    }
+}

--- a/plugins/snmp/Configs/plugin-snmp-cisco-ios-system-stats
+++ b/plugins/snmp/Configs/plugin-snmp-cisco-ios-system-stats
@@ -1,0 +1,288 @@
+plugin {
+    id 10011
+    plugin SNMP.CISCO.IOS.SysStats
+    command check-snmp-cisco-ios-system-stats
+    datatype statistic
+    category Network,SNMP
+    netaccess yes
+    prefer localhost
+    abstract Check snmp-cisco-ios-system-stats
+    description Monitor CPU and memory statistics of a Cisco IOS device
+}
+
+
+statistic {
+    statkey CPUInterrupt
+    alias CPUInterrupt
+    datatype bigint
+    units percent
+    description The overall CPU busy percentage in the interrupt context in the last 5 second period
+}
+
+statistic {
+    statkey IOMemFreePercent
+    alias IOMemFreePercent
+    datatype bigint
+    units percent
+    description Free memory of the IO pool in percent
+}
+
+statistic {
+    statkey IOMemTotal
+    alias IOMemTotal
+    datatype bigint
+    units bytes
+    description Non utilized memory in the IO memory pool
+}
+
+statistic {
+    statkey CPUTotal5sec
+    alias CPUTotal5sec
+    datatype bigint
+    units percent
+    description The overall CPU busy percentage in the last 5 second period
+}
+
+statistic {
+    statkey CPUMemTotal
+    alias CPUMemTotal
+    datatype bigint
+    units bytes
+    description Total memory available in the processor pool
+}
+
+statistic {
+    statkey IOMemFree
+    alias IOMemFree
+    datatype bigint
+    units bytes
+    description The number of bytes from the IO memory pool that are currently unused
+}
+
+statistic {
+    statkey CPUMemFree
+    alias CPUMemFree
+    datatype bigint
+    units bytes
+    description The number of bytes from the processor memory pool that are currently unused
+}
+
+statistic {
+    statkey IOMemUsedPercent
+    alias IOMemUsedPercent
+    datatype bigint
+    units percent
+    description Utilization of the IO memory pool
+}
+
+statistic {
+    statkey CPUMemLargestFree
+    alias CPUMemLargestFree
+    datatype bigint
+    units bytes
+    description The largest number of contiguous bytes from the processor memory pool that are currently unused
+}
+
+statistic {
+    statkey CPUMemUsed
+    alias CPUMemUsed
+    datatype bigint
+    units bytes
+    description The number of bytes from the processor memory pool that are currently in use
+}
+
+statistic {
+    statkey IOMemUsed
+    alias IOMemUsed
+    datatype bigint
+    units bytes
+    description The number of bytes from the IO memory pool that are currently in use
+}
+
+statistic {
+    statkey CPUMemFreePercent
+    alias CPUMemFreePercent
+    datatype bigint
+    units percent
+    description Non utilized memory in the processor memory pool
+}
+
+statistic {
+    statkey CPUTotal1min
+    alias CPUTotal1min
+    datatype bigint
+    units percent
+    description The overall CPU busy percentage in the last 1 minute period
+}
+
+statistic {
+    statkey CPUTotal5min
+    alias CPUTotal5min
+    datatype bigint
+    units percent
+    description The overall CPU busy percentage in the last 5 minute period
+}
+
+statistic {
+    statkey IOMemLargestFree
+    alias IOMemLargestFree"
+    datatype bigint
+    units bytes
+    description The largest number of contiguous bytes from the IO memory pool that are currently unused
+}
+
+statistic {
+    statkey CPUMemUsedPercent
+    alias CPUMemUsedPercent
+    datatype bigint
+    units bytes
+    description Utilization of the processor memory pool
+}
+
+chart {
+    id 1
+    title CPU Load
+    options {
+        ylabel percent
+        units percent
+        chart-type line
+        series {
+            name CPUTotal5sec
+            color \#005467
+        }
+        series {
+            name CPUTotal1min
+            color \#ffb244
+        }
+        series {
+            name CPUTotal5min
+            color \#2ba743
+        }
+    }
+}
+
+chart {
+    id 2
+    title CPU avg 5sec - and interrupt load
+    options {
+        ylabel percent
+        units percent
+        chart-type line
+        series {
+            name CPUTotal5sec
+            color \#005467
+        }
+        series {
+            name CPUInterrupt
+            color \#ffb244
+        }
+    }
+}
+
+chart {
+    id 3
+    title IO Memory Pool Utilization
+    options {
+        ylabel percent
+        units percent
+        chart-type area
+        series {
+            name IOMemFreePercent
+            color \#005467
+        }
+        series {
+            name IOMemUsedPercent
+            color \#ffb244
+        }
+    }
+}
+
+chart {
+    id 4
+    title Processor Memory Pool Utilization
+    options {
+        ylabel percent
+        units percent
+        chart-type area
+        series {
+            name CPUMemFreePercent
+            color \#005467
+        }
+        series {
+            name CPUMemUsedPercent
+            color \#ffb244
+        }
+    }
+}
+
+chart {
+    id 5
+    title IO Memory Pool Usage
+    options {
+        ylabel bytes
+        units bytes
+        chart-type area
+        series {
+            name IOMemFree
+            color \#005467
+        }
+        series {
+            name IOMemUsed
+            color \#ffb244
+        }
+    }
+}
+
+chart {
+    id 6
+    title Processor Memory Pool Usage
+    options {
+        ylabel bytes
+        units bytes
+        chart-type area
+        series {
+            name CPUMemFree
+            color \#005467
+        }
+        series {
+            name CPUMemUsed
+            color \#ffb244
+        }
+    }
+}
+
+chart {
+    id 7
+    title Largest number of free contiguous bytes
+    options {
+        ylabel bytes
+        units bytes
+        chart-type area
+        series {
+            name IOMemLargestFree
+            color \#005467
+        }
+        series {
+            name CPUMemLargestFree
+            color \#ffb244
+        }
+    }
+}
+
+chart {
+    id 8
+    title Total number of used bytes by memory pools
+    options {
+        ylabel bytes
+        units bytes
+        chart-type area
+        series {
+            name IOMemTotal
+            color \#005467
+        }
+        series {
+            name CPUMemTotal
+            color \#ffb244
+        }
+    }
+}

--- a/plugins/snmp/Configs/plugin-snmp-cpu-linux
+++ b/plugins/snmp/Configs/plugin-snmp-cpu-linux
@@ -1,0 +1,144 @@
+plugin {
+    id 10004
+    plugin SNMP.CPU.Linux
+    command check-snmp-cpu-linux
+    datatype statistic
+    category Network,SNMP
+    abstract CPU check
+    description Linux CPU statistics SNMP
+}
+
+statistic {
+    statkey user
+    alias User
+    datatype float
+    units percent
+    description Percentage of CPU utilization at the user level.
+}
+
+statistic {
+    statkey nice
+    alias Nice
+    datatype float
+    units percent
+    description Time spent in user mode with low priority.
+}
+
+statistic {
+    statkey system
+    alias System
+    datatype float
+    units percent
+    description Percentage of CPU utilization at the system level.
+}
+
+statistic {
+    statkey idle
+    alias Idle
+    datatype float
+    units percent
+    description Percentage of time the CPU is in idle state.
+}
+
+statistic {
+    statkey iowait
+    alias IOwait
+    datatype float
+    units percent
+    description Percentage of time the CPU is in idle state because an i/o operation is waiting for a disk. This statistic is only available since kernel version 2.5.41.
+}
+
+statistic {
+    statkey irq
+    alias IRQ
+    datatype float
+    units percent
+    description Percentage of time the CPU is servicing interrupts. This statistic is only available since kernel version 2.6.0-test4.
+}
+
+statistic {
+    statkey softirq
+    alias Soft IRQ
+    datatype float
+    units percent
+    description Percentage of time the CPU is servicing softirqs. This statistic is only available since kernel version 2.6.0-test4.
+}
+
+statistic {
+    statkey steal
+    alias Steal
+    datatype float
+    units percent
+    description Percentage of stolen CPU time, which is the time spent in other operating systems when running in a virtualized environment. This statistic is only available since kernel version 2.6.11.
+}
+
+statistic {
+    statkey guest
+    alias Guest
+    datatype float
+    units percent
+    description Percentage of CPU time, which is the time spent running a virtual CPU for guest operating systems under the control of the Linux kernel. This statistic is only available since kernel version 2.6.24.
+}
+
+statistic {
+    statkey total
+    alias Total
+    datatype float
+    units percent
+    description The total usage of the CPU in percent.
+}
+
+statistic {
+    statkey other
+    alias Other
+    datatype float
+    units percent
+    description Usage of CPU which don't have counter over snmp
+}
+
+chart {
+    id 1
+    title Linux - cpu usage
+    options {
+        ylabel cpu usage in %
+        units null
+        chart-type area
+        stack true
+        series {
+            name system
+            color \#ffb244
+        }
+        series {
+            name user
+            color \#9a72ad
+        }
+        series {
+            name iowait
+            color \#ff0000
+        }
+        series {
+            name nice
+            color \#005467
+        }
+        series {
+            name irq
+            color \#2ba743
+        }
+        series {
+            name softirq
+            color \#7648eb
+        }
+        series {
+            name steal
+            color \#e9644a
+        }
+        series {
+            name guest
+            color \#666666
+        }
+        series {
+            name other
+            color \#bf00bf
+        }
+    }
+}

--- a/plugins/snmp/Configs/plugin-snmp-ios-proc
+++ b/plugins/snmp/Configs/plugin-snmp-ios-proc
@@ -1,0 +1,146 @@
+plugin {
+    id 10010
+    plugin SNMP.IOS.Process
+    command check-snmp-ios-proc
+    datatype statistic
+    category Network,SNMP
+    netaccess yes
+    prefer localhost
+    abstract Check snmp-ios-proc
+    description Monitor the process of a Cisco IOS Device.
+}
+
+statistic {
+    statkey Priority
+    alias Priority
+    datatype varchar(20)
+    units bytes
+    description The priority level at which the process is running.
+}
+
+statistic {
+    statkey Util5Sec
+    alias Util5Sec
+    datatype bigint
+    units percent
+    description A estimate of how busy a process caused the processor to be over a 5 second period.
+}
+
+statistic {
+    statkey Util1Min
+    alias Util1Min
+    datatype bigint
+    units percent
+    description A estimate of how busy a process caused the processor to be over a 1 minute period.
+}
+
+statistic {
+    statkey Util5Min
+    alias Util5Min
+    datatype bigint
+    units percent
+    description A estimate of how busy a process caused the processor to be over a 5 minutes period.
+}
+
+statistic {
+    statkey MemAllocated
+    alias MemAllocated
+    datatype float
+    units bytes
+    description The sum of all the dynamically allocated memory that this process has received from the system.
+}
+
+statistic {
+    statkey MemFreed
+    alias MemFreed
+    datatype float
+    units bytes
+    description The sum of all memory that this process has returned to the system.
+}
+
+statistic {
+    statkey Invoked
+    alias Invoked
+    datatype float
+    units default
+    description The number of times since cpmTimeCreated that the process has been invoked.
+}
+
+statistic {
+    statkey Runtime
+    alias Runtime
+    datatype float
+    units default
+    description The amount of CPU time the process has used, in microseconds.
+}
+
+
+
+chart {
+    id 1
+    title SNMP IOS Process Load
+    options {
+        ylabel percent
+        units percent
+        chart-type line
+        series {
+            name Util5Sec
+            color \#9a72ad
+        }
+        series {
+            name Util1Min
+            color \#e9644a
+        }
+        series {
+            name Util5Min
+            color \#ffb244
+        }
+    }
+}
+
+chart {
+    id 2
+    title SNMP IOS Process Memory
+    options {
+        ylabel bytes/s
+        units bytes
+        chart-type area
+        series {
+            name MemAllocated
+            color \#005467
+        }
+        series {
+            name MemFreed
+            color \#ff7a0d
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 3
+    title SNMP IOS Process Invokes
+    options {
+        ylabel Invokes/s
+        units default
+        chart-type area
+        series {
+            name Invoked
+            color \#ffb244
+        }
+    }
+}
+
+chart {
+    id 4
+    title SNMP IOS Process Runtime
+    options {
+        ylabel microseconds
+        units default
+        chart-type area
+        series {
+            name Runtime
+            color \#ffb244
+        }
+    }
+}

--- a/plugins/snmp/Configs/plugin-snmp-nbar
+++ b/plugins/snmp/Configs/plugin-snmp-nbar
@@ -1,0 +1,85 @@
+plugin {
+    id 10005
+    plugin SNMP.NBAR
+    command check-snmp-nbar
+    datatype statistic
+    category Network,SNMP
+    netaccess yes
+    prefer localhost
+    abstract Check snmp-nbar
+    description Checks protocol statistics of an interfaces.
+}
+
+
+statistic {
+    statkey in_proto_octets
+    alias in_proto_octets
+    datatype float
+    units bytes
+    description The number of bytes received by the protocol on the interface
+}
+
+statistic {
+    statkey out_proto_octets
+    alias out_proto_octets
+    datatype float
+    units bytes
+    description The number of bytes send by the protocol on the interface
+}
+
+statistic {
+    statkey in_proto_pkts
+    alias in_proto_pkts
+    datatype float
+    units bytes
+    description The number of packets received by the protocol on the interface
+}
+
+statistic {
+    statkey iops_write
+    alias lvIoWrite
+    datatype float
+    units bytes
+    description The number of packets send by the protocol on the interface
+}
+
+
+chart {
+    id 1
+    title SNMP NBAR - in/out octets
+    options {
+        ylabel bytes received(+) / send(-)
+        units bytes
+        chart-type area
+        series {
+            name in_proto_octets
+            color \#005467
+        }
+        series {
+            name out_proto_octets
+            color \#ff7a0d
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 2
+    title SNMP NBAR - in/out packets
+    options {
+        packets received(+) / send(-)
+        units default
+        chart-type area
+        series {
+            name in_proto_pkts
+            color \#005467
+        }
+        series {
+            name out_proto_pkts
+            color \#ff7a0d
+            opposite true
+        }
+    }
+}
+
+

--- a/plugins/snmp/Configs/plugin-snmp-qos-queue
+++ b/plugins/snmp/Configs/plugin-snmp-qos-queue
@@ -1,0 +1,352 @@
+plugin {
+    id 10006
+    plugin SNMP.QOS.QUEUE
+    command check-snmp-qos-queue
+    datatype statistic
+    category Network,SNMP
+    netaccess yes
+    prefer localhost
+    abstract Check snmp-qos-queue
+    description Monitor the Egress QoS queue of interface of a Cisco Switch
+}
+
+
+statistic {
+    statkey q1_w1_enqueue
+    alias q1_w1_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 1 with weight 1
+}
+
+statistic {
+    statkey q1_w2_enqueue
+    alias q1_w2_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 1 with weight 2
+}
+
+statistic {
+    statkey q1_w3_enqueue
+    alias q1_w3_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 1 with weight 3
+}
+
+statistic {
+    statkey q2_w1_enqueue
+    alias q2_w1_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 2 with weight 1
+}
+
+statistic {
+    statkey q2_w2_enqueue
+    alias q2_w2_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 2 with weight 2
+}
+
+statistic {
+    statkey q2_w3_enqueue
+    alias q2_w3_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 2 with weight 3
+}
+
+statistic {
+    statkey q3_w1_enqueue
+    alias q3_w1_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 3 with weight 1
+}
+
+statistic {
+    statkey q3_w2_enqueue
+    alias q3_w2_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 3 with weight 2
+}
+
+statistic {
+    statkey q3_w3_enqueue
+    alias q3_w3_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 3 with weight 3
+}
+
+statistic {
+    statkey q4_w1_enqueue
+    alias q4_w1_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 3 with weight 1
+}
+
+statistic {
+    statkey q4_w2_enqueue
+    alias q4_w2_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 3 with weight 2
+}
+
+statistic {
+    statkey q4_w3_enqueue
+    alias q4_w3_enqueue
+    datatype float
+    units default
+    description Enqueued packets in queue 3 with weight 3
+}
+
+statistic {
+    statkey q1_w1_drop
+    alias q1_w1_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 1 with weight 1
+}
+
+statistic {
+    statkey q1_w2_drop
+    alias q1_w2_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 1 with weight 2
+}
+
+statistic {
+    statkey q1_w3_drop
+    alias q1_w3_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 1 with weight 3
+}
+
+statistic {
+    statkey q2_w1_drop
+    alias q2_w1_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 2 with weight 1
+}
+
+statistic {
+    statkey q2_w2_drop
+    alias q2_w2_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 2 with weight 2
+}
+
+statistic {
+    statkey q2_w3_drop
+    alias q2_w3_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 2 with weight 3
+}
+
+statistic {
+    statkey q3_w1_drop
+    alias q3_w1_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 3 with weight 1
+}
+
+statistic {
+    statkey q3_w2_drop
+    alias q3_w2_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 3 with weight 2
+}
+
+statistic {
+    statkey q3_w3_drop
+    alias q3_w3_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 3 with weight 3
+}
+
+statistic {
+    statkey q4_w1_drop
+    alias q4_w1_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 3 with weight 1
+}
+
+statistic {
+    statkey q4_w2_drop
+    alias q4_w2_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 3 with weight 2
+}
+
+statistic {
+    statkey q4_w3_drop
+    alias q4_w3_drop
+    datatype float
+    units bytes
+    description Dropped packets in queue 3 with weight 3
+}
+
+chart {
+    id 1
+    title SNMP QOS QUEUE 1 - enqueue/drop packets"
+    options {
+        ylabel packets drop(-)  / enqueue(+)
+        units default
+        chart-type area
+        series {
+            name q1_w1_enqueue
+            color \#005467
+        }
+        series {
+            name q1_w2_enqueue
+            color \#ffb244
+        }
+        series {
+            name q1_w3_enqueue
+            color \#2ba743
+        }
+        series {
+            name q1_w1_drop
+            color \#ff7a0d
+            opposite true
+        }
+        series {
+            name q1_w2_drop
+            color \#e9644a
+            opposite true
+        }
+        series {
+            name q1_w3_drop
+            color \#9a72ad
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 2
+    title SNMP QOS QUEUE 1 - enqueue/drop packets"
+    options {
+        ylabel packets drop(-)  / enqueue(+)
+        units default
+        chart-type area
+        series {
+            name q2_w1_enqueue
+            color \#005467
+        }
+        series {
+            name q2_w2_enqueue
+            color \#ffb244
+        }
+        series {
+            name q2_w3_enqueue
+            color \#2ba743
+        }
+        series {
+            name q2_w1_drop
+            color \#ff7a0d
+            opposite true
+        }
+        series {
+            name q2_w2_drop
+            color \#e9644a
+            opposite true
+        }
+        series {
+            name q2_w3_drop
+            color \#9a72ad
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 3
+    title SNMP QOS QUEUE 3 - enqueue/drop packets"
+    options {
+        ylabel packets drop(-)  / enqueue(+)
+        units default
+        chart-type area
+        series {
+            name q3_w1_enqueue
+            color \#005467
+        }
+        series {
+            name q3_w2_enqueue
+            color \#ffb244
+        }
+        series {
+            name q3_w3_enqueue
+            color \#2ba743
+        }
+        series {
+            name q3_w1_drop
+            color \#ff7a0d
+            opposite true
+        }
+        series {
+            name q3_w2_drop
+            color \#e9644a
+            opposite true
+        }
+        series {
+            name q3_w3_drop
+            color \#9a72ad
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 4
+    title SNMP QOS QUEUE 4 - enqueue/drop packets"
+    options {
+        ylabel packets drop(-)  / enqueue(+)
+        units default
+        chart-type area
+        series {
+            name q4_w1_enqueue
+            color \#005467
+        }
+        series {
+            name q4_w2_enqueue
+            color \#ffb244
+        }
+        series {
+            name q4_w3_enqueue
+            color \#2ba743
+        }
+        series {
+            name q4_w1_drop
+            color \#ff7a0d
+            opposite true
+        }
+        series {
+            name q4_w2_drop
+            color \#e9644a
+            opposite true
+        }
+        series {
+            name q4_w3_drop
+            color \#9a72ad
+            opposite true
+        }
+    }
+}

--- a/plugins/snmp/Configs/plugin-snmp-rmon
+++ b/plugins/snmp/Configs/plugin-snmp-rmon
@@ -1,0 +1,256 @@
+plugin {
+    id 10009
+    plugin SNMP.QOS.RMON
+    command check-snmp-rmon
+    datatype statistic
+    category Network,SNMP
+    netaccess yes
+    prefer localhost
+    abstract Check snmp-qos-rmon
+    description Monitor the rmon stats of a interface on a switch
+}
+
+
+statistic {
+    statkey DropEvents
+    alias DropEvents
+    datatype float
+    units default
+    description The total number of events in which packets were dropped by the probe due to lack of resources
+}
+
+statistic {
+    statkey Octets
+    alias Octets
+    datatype float
+    units bytes
+    description The total number of octets of data
+}
+
+statistic {
+    statkey Pkts
+    alias Pkts
+    datatype float
+    units default
+    description The total number of packets received
+}
+
+statistic {
+    statkey BroadcastPkts
+    alias BroadcastPkts
+    datatype float
+    units default
+    description The total number of good packets received that were directed to the broadcast address
+}
+
+statistic {
+    statkey MulticastPkts
+    alias MulticastPkts
+    datatype float
+    units default
+    description The total number of good packets received that were directed to a multicast address
+}
+
+statistic {
+    statkey CRCAlignErrors
+    alias CRCAlignErrors
+    datatype float
+    units default
+    description The total number of packets received that had a bad FCS
+}
+
+statistic {
+    statkey UndersizePkts
+    alias UndersizePkts
+    datatype float
+    units default
+    description The total number of packets received that were less than 64 octets long
+}
+
+statistic {
+    statkey OversizePkts
+    alias OversizePkts
+    datatype float
+    units default
+    description The total number of packets received that were longer than 1518 octets
+}
+
+statistic {
+    statkey Fragments
+    alias Fragments
+    datatype float
+    units default
+    description The total number of packets received that were less than 64 octets in length
+}
+
+statistic {
+    statkey Jabbers
+    alias Jabbers
+    datatype float
+    units default
+    description The total number of packets received that were longer than 1518 octets
+}
+
+statistic {
+    statkey Collisions
+    alias Collisions
+    datatype float
+    units default
+    description The best estimate of the total number of collisions on this Ethernet segment
+}
+
+statistic {
+    statkey Pkts64Octets
+    alias Pkts64Octets
+    datatype float
+    units default
+    description The total number of packets received that were 64 octets in length
+}
+
+statistic {
+    statkey Pkts65to127Octets
+    alias Pkts65to127Octets
+    datatype float
+    units default
+    description The total number of packets received that were between 65 and 127 octets in length
+}
+
+statistic {
+    statkey Pkts128to255Octets
+    alias Pkts128to255Octets
+    datatype float
+    units default
+    description The total number of packets received that were between 128 and 255 octets in length
+}
+
+statistic {
+    statkey Pkts256to511Octets
+    alias Pkts256to511Octets
+    datatype float
+    units default
+    description The total number of packets received that were between 256 and 511 octets in length
+}
+
+statistic {
+    statkey Pkts512to1023Octets
+    alias Pkts512to1023Octets
+    datatype float
+    units default
+    description The total number of packets received that were between 512 and 1023 octets in length
+}
+
+statistic {
+    statkey Pkts1024to1518Octets
+    alias Pkts1024to1518Octets
+    datatype float
+    units default
+    description The total number of packets received that were between 1024 and 1518 octets in length
+}
+
+
+chart {
+    id 1
+    title SNMP RMON Interface Bytes"
+    options {
+        ylabel bytes/s
+        units bytes
+        chart-type area
+        series {
+            name Octets
+            color \#005467
+        }
+    }
+}
+
+chart {
+    id 2
+    title SNMP RMON Interface Pakets"
+    options {
+        ylabel packets/s
+        units default
+        chart-type line
+        series {
+            name Pkts
+            color \#005467
+        }
+        series {
+            name BroadcastPkts
+            color \#ffb244
+        }
+        series {
+            name MulticastPkts
+            color \#2ba743
+        }
+    }
+}
+
+chart {
+    id 3
+    title SNMP RMON Interface Pakets Errors"
+    options {
+        ylabel packets/s
+        units default
+        chart-type area
+        series {
+            name CRCAlignErrors
+            color \#005467
+        }
+        series {
+            name UndersizePkts
+            color \#ffb244
+        }
+        series {
+            name OversizePkts
+            color \#2ba743
+        }
+        series {
+            name Fragments
+            color \#ff7a0d
+        }
+        series {
+            name Jabbers
+            color \#e9644a
+        }
+        series {
+            name Collisions
+            color \#9a72ad
+        }
+    }
+}
+
+chart {
+    id 4
+    title SNMP RMON Interface Pakets sizes"
+    options {
+        ylabel packets/s
+        units default
+        chart-type line
+        series {
+            name Pkts64Octets
+            color \#005467
+        }
+        series {
+            name Pkts65to127Octets
+            color \#ffb244
+        }
+        series {
+            name Pkts128to255Octets
+            color \#2ba743
+        }
+        series {
+            name Pkts256to511Octets
+            color \#ff7a0d
+            opposite true
+        }
+        series {
+            name Pkts512to1023Octets
+            color \#e9644a
+            opposite true
+        }
+        series {
+            name Pkts1024to1518Octets
+            color \#9a72ad
+            opposite true
+        }
+    }
+}

--- a/plugins/snmp/Configs/plugin-snmp-syno-disk
+++ b/plugins/snmp/Configs/plugin-snmp-syno-disk
@@ -1,0 +1,124 @@
+plugin {
+    id 10002
+    plugin SNMP.Syno.Disk
+    command check-snmp-syno-disk
+    datatype statistic
+    category Network,SNMP
+    netaccess yes
+    prefer localhost
+    abstract Check snmp-syno-disk
+    description Check the disk of a Synology NAS.
+}
+
+
+statistic {
+    statkey bytes_read
+    alias diskBytesRead
+    datatype float
+    units bytes
+    description The number of bytes read from this device
+}
+
+statistic {
+    statkey bytes_write
+    alias diskBytesWrite
+    datatype float
+    units bytes
+    description The number of bytes written to this device
+}
+
+statistic {
+    statkey iops_read
+    alias diskIoRead
+    datatype float
+    units bytes
+    description The number of read accesses from this device
+}
+
+statistic {
+    statkey iops_write
+    alias diskIoWrite
+    datatype float
+    units bytes
+    description The number of write accesses to this device
+}
+
+statistic {
+    statkey avg_load
+    alias diskAvgLoad
+    datatype bigint
+    units percent
+    description average load of disk
+}
+
+statistic {
+    statkey avg_read_io_size
+    alias diskAvgReadIoSize
+    datatype float
+    units bytes
+    description The number of bytes read from this device
+}
+
+statistic {
+    statkey avg_write_io_size
+    alias diskAvgWriteIoSize
+    datatype float
+    units bytes
+    description The number of bytes written to this device
+}
+
+
+
+chart {
+    id 1
+    title SNMP syno disk - read/write rate
+    options {
+        ylabel bytes read(+) / write(-)
+        units bytes
+        chart-type area
+        series {
+            name bytes_read
+            color \#005467
+        }
+        series {
+            name bytes_write
+            color \#ff7a0d
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 2
+    title SNMP syno disk - read/write IOPS
+    options {
+        ylabel iops read(+) / write(-)
+        units default
+        chart-type area
+        series {
+            name iops_read
+            color \#005467
+        }
+        series {
+            name iops_write
+            color \#ff7a0d
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 3
+    title Disk Load Percent
+    options {
+        ylabel percent
+        units null
+        chart-type area
+        series {
+            name avg_load
+            color \#005467
+        }
+    }
+}
+
+

--- a/plugins/snmp/Configs/plugin-snmp-syno-lv
+++ b/plugins/snmp/Configs/plugin-snmp-syno-lv
@@ -1,0 +1,142 @@
+plugin {
+    id 10003
+    plugin SNMP.Syno.Lv
+    command check-snmp-syno-lv
+    datatype statistic
+    category Network,SNMP
+    netaccess yes
+    prefer localhost
+    abstract Check snmp-syno-lv
+    description Check the logical volume of a Synology NAS.
+}
+
+
+statistic {
+    statkey bytes_read
+    alias lvBytesRead
+    datatype float
+    units bytes
+    description The number of bytes read from this device
+}
+
+statistic {
+    statkey bytes_write
+    alias lvBytesWrite
+    datatype float
+    units bytes
+    description The number of bytes written to this device
+}
+
+statistic {
+    statkey iops_read
+    alias lvIoRead
+    datatype float
+    units bytes
+    description The number of read accesses from this device
+}
+
+statistic {
+    statkey iops_write
+    alias lvIoWrite
+    datatype float
+    units bytes
+    description The number of write accesses to this device
+}
+
+statistic {
+    statkey avg_read_io_size
+    alias volumeAvgIoReadSize
+    datatype float
+    units bytes
+    description The average size of Read IO
+}
+
+statistic {
+    statkey avg_write_io_size"
+    alias volumeAvgIoWriteSize
+    datatype float
+    units bytes
+    description The average size of Write IO
+}
+
+
+statistic {
+    statkey avg_load
+    alias lvAvgLoad
+    datatype bigint
+    units percent
+    description average load of lv
+}
+
+
+chart {
+    id 1
+    title SNMP syno lv - read/write rate
+    options {
+        ylabel bytes read(+) / write(-)
+        units bytes
+        chart-type area
+        series {
+            name bytes_read
+            color \#005467
+        }
+        series {
+            name bytes_write
+            color \#ff7a0d
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 2
+    title SNMP syno lv - read/write IOPS
+    options {
+        ylabel iops read(+) / write(-)
+        units default
+        chart-type area
+        series {
+            name iops_read
+            color \#005467
+        }
+        series {
+            name iops_write
+            color \#ff7a0d
+            opposite true
+        }
+    }
+}
+
+chart {
+    id 3
+    title lv Load Percent
+    options {
+        ylabel percent
+        units null
+        chart-type area
+        series {
+            name avg_load
+            color \#005467
+        }
+    }
+}
+
+chart {
+    id 4
+    title SNMP syno lv - average read/write IOPS size
+    options {
+        ylabel iops size read(+) / size write(-)
+        units bytes
+        chart-type area
+        series {
+            name avg_read_io_size
+            color \#005467
+        }
+        series {
+            name avg_write_io_size
+            color \#ff7a0d
+            opposite true
+        }
+    }
+}
+

--- a/plugins/snmp/Configs/plugin-snmp-temperature
+++ b/plugins/snmp/Configs/plugin-snmp-temperature
@@ -1,0 +1,33 @@
+plugin {
+    id 10001
+    plugin SNMP.Check.Temperature
+    command check-snmp-temperature
+    datatype statistic
+    category System,SNMP
+    netaccess yes
+    prefer localhost
+    abstract SNMP Temperature check by OID
+    description Check the Temperature of a Device by OID.
+}
+statistic {
+    statkey temperature
+    alias Temperature
+    datatype float
+    units temperature
+    description The temperatur of the sensor.
+}
+
+chart {
+    id 1
+    title Temperature
+    options {
+        ylabel celsius
+        units null
+        chart-type area
+        series {
+            name temperature
+            color \#005467
+        }
+    }
+}
+


### PR DESCRIPTION
- plugin-snmp-cpu-linux (id 10004)

Ließt CPU Statistiken einen Linux basierendem System via SNMP aus.

- plugin-snmp-nbar (id 10005)

Dieses plugin funktioniert nur mit Cisco Routern, welches das Feature NBAR aktviert haben. Es ließt für ein Interface den Durchsatz eines Protokolls (http, https, rtp etc.) aus.

- plugin-snmp-syno-disk (id 10002)

Ein Plugin für Synology NAS Systeme. Es ließt Auslastung einer Festplatte in Prozent aus, den Durchsatz der Festplatte und die Anzahl der IOPS. Zusätzlich wird die durchschnittliche IO-Größe errechnet.

- plugin-snmp-syno-lv (id 10003)

Das gleiche wie plugin-snmp-syno-disk nur hier wird das Raid-Array überwacht.

- plugin-snmp-cisco-fw (id 10008)

Hiermit kann man die Firewall eines Cisco Routers im Auge behalten. Könnte auch mit einer ASA funktionieren, habe das aber nicht getestet und mir die MIBs der ASAs nicht angeschaut.

- plugin-snmp-cisco-ios-system-stats (id 10011)

Überwacht CPU und Speicher eines Cisco Router oder Switch, der mit IOS läuft.

- plugin-snmp-ios-proc (id 10010)

Hiermit kann man einzelne Prozesse eines IOS basierenden Routers oder Switch überwachen

- plugin-snmp-qos-queue (id 10006)

Wird wohl nur mit Cisco 3750 Switchen funktionieren und behält die QoS Egress Queues im Auge.

- plugin-snmp-rmon (id 10009)

RMON Statistiken von einer Netzwerkswitch, welcher die Funktion implementiert und die MIB unterstützt.

- plugin-snmp-temperature (id 10001)

Total primitiver fork um mit der Angabe einer OID ein gauge-value auszulesen und in ein Chart zu drücken. Primär dazu gedacht Temperaturen im Auge zu behalten.